### PR TITLE
[FEAT] Post flow updated and improved error handling

### DIFF
--- a/lib/config/strings_home.dart
+++ b/lib/config/strings_home.dart
@@ -54,4 +54,17 @@ class StringsHome {
   static String acknowledgmentAmountOfPoints(String pointsToGive) {
     return 'Tienes $pointsToGive puntos para reconocer a tus compañeros.';
   }
+
+  // 3-Step Recognize Flow
+  static const String step1ChooseBadge = 'Elige una insignia';
+  static const String step1BadgeCostInfo = 'Cada insignia cuesta 10 puntos';
+  static const String step2SearchLabel = 'A quién quieres reconocer?';
+  static const String step2SearchHint = 'Buscar compañero...';
+  static const String step2NoResults = 'No se encontraron resultados';
+  static const String step3WriteLabel = 'Escribe tu reconocimiento';
+  static const String step3SendButton = 'Enviar reconocimiento';
+  static const String acknowledgmentSuccess =
+      'Reconocimiento enviado exitosamente';
+  static const String acknowledgmentError =
+      'Error al enviar reconocimiento';
 }

--- a/lib/features/home/data/repositories/default_company_feeds_repository.dart
+++ b/lib/features/home/data/repositories/default_company_feeds_repository.dart
@@ -1,4 +1,5 @@
 import 'package:bondly_app/features/auth/domain/models/user_model.dart';
+import 'package:bondly_app/src/api_calls_handler.dart' show ApiErrorException;
 import 'package:bondly_app/features/home/data/repositories/api/akcnowledgments_api.dart';
 import 'package:bondly_app/features/home/data/repositories/api/ambassadors_api.dart';
 import 'package:bondly_app/features/home/data/repositories/api/announcements_api.dart';
@@ -123,6 +124,9 @@ class DefaultCompanyFeedsRepository extends CompanyFeedsRepository {
       return Result.success(await _createAcknowledgmentAPI.createAcknowledgment(
           badgeId, message, recipients));
     } catch (exception) {
+      if (exception is ApiErrorException) {
+        return Result.error(exception);
+      }
       return Result.error(NoConnectionException());
     }
   }

--- a/lib/features/home/ui/screens/tab_feed.dart
+++ b/lib/features/home/ui/screens/tab_feed.dart
@@ -62,6 +62,7 @@ class _FeedTabState extends State<FeedTab> {
         color: colors.accent,
         onRefresh: _onRefresh,
         child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
           children: [
             _buildSliderSection(),
             const SizedBox(height: 12),
@@ -75,6 +76,7 @@ class _FeedTabState extends State<FeedTab> {
       color: colors.accent,
       onRefresh: _onRefresh,
       child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
         padding: EdgeInsets.zero,
         itemCount: posts.length + 1, // +1 for the slider header
         itemBuilder: (context, index) {

--- a/lib/features/home/ui/screens/tab_recognize.dart
+++ b/lib/features/home/ui/screens/tab_recognize.dart
@@ -1,17 +1,157 @@
+import 'dart:async';
+
 import 'package:bondly_app/config/colors.dart';
 import 'package:bondly_app/config/dimensions.dart';
 import 'package:bondly_app/config/strings_home.dart';
+import 'package:bondly_app/features/home/domain/models/badge_model.dart';
 import 'package:bondly_app/features/home/ui/viewmodels/home_viewmodel.dart';
-import 'package:bondly_app/ui/shared/badge_icon_button.dart';
+import 'package:bondly_app/ui/shared/badge_icon_button.dart' show BadgeType;
 import 'package:bondly_app/ui/shared/info_card.dart';
-import 'package:bondly_app/ui/shared/points_card.dart';
 import 'package:bondly_app/ui/shared/slider_banner_card.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Badge;
+import 'package:google_fonts/google_fonts.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 
-class RecognizeTab extends StatelessWidget {
+enum RecognizeStep { selectBadge, selectPerson, writeMessage }
+
+class RecognizeTab extends StatefulWidget {
   final HomeViewModel model;
   const RecognizeTab({super.key, required this.model});
+
+  @override
+  State<RecognizeTab> createState() => _RecognizeTabState();
+}
+
+class _RecognizeTabState extends State<RecognizeTab> {
+  RecognizeStep _currentStep = RecognizeStep.selectBadge;
+  int _activeCategoryIndex = -1;
+  Map<String, dynamic>? _selectedPerson;
+
+  final TextEditingController _searchController = TextEditingController();
+  Timer? _debounceTimer;
+  String _searchQuery = '';
+
+  final TextEditingController _messageController = TextEditingController();
+
+  HomeViewModel get model => widget.model;
+
+  @override
+  void initState() {
+    super.initState();
+    _messageController.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _messageController.dispose();
+    _debounceTimer?.cancel();
+    super.dispose();
+  }
+
+  void _goToStep(RecognizeStep step) {
+    setState(() => _currentStep = step);
+  }
+
+  void _resetToStep1() {
+    setState(() {
+      _currentStep = RecognizeStep.selectBadge;
+      _activeCategoryIndex = -1;
+      _selectedPerson = null;
+      _searchController.clear();
+      _searchQuery = '';
+      _messageController.clear();
+      model.selectedBadge = null;
+      model.collaboratorsIds = [];
+    });
+  }
+
+  void _resetToStep2() {
+    setState(() {
+      _currentStep = RecognizeStep.selectPerson;
+      _selectedPerson = null;
+      _messageController.clear();
+      _searchController.clear();
+      _searchQuery = '';
+      model.collaboratorsIds = [];
+    });
+  }
+
+  BadgeType _badgeTypeForIndex(int index) {
+    switch (index) {
+      case 0:
+        return BadgeType.competencias;
+      case 1:
+        return BadgeType.especiales;
+      case 2:
+        return BadgeType.valores;
+      default:
+        return BadgeType.competencias;
+    }
+  }
+
+  String _categoryLabelForIndex(int index) {
+    switch (index) {
+      case 0:
+        return StringsHome.badgeCompetencias;
+      case 1:
+        return StringsHome.badgeEspeciales;
+      case 2:
+        return StringsHome.badgeValores;
+      default:
+        return '';
+    }
+  }
+
+  IconData _defaultIconForBadgeType(BadgeType type) {
+    switch (type) {
+      case BadgeType.competencias:
+        return LucideIcons.award;
+      case BadgeType.especiales:
+        return LucideIcons.star;
+      case BadgeType.valores:
+        return LucideIcons.heart;
+    }
+  }
+
+  LinearGradient _gradientForCategoryIndex(int index) {
+    switch (index) {
+      case 0:
+        return const LinearGradient(
+          begin: Alignment.topRight,
+          end: Alignment.bottomLeft,
+          colors: [
+            BondlyColors.badgeCompetenciasStart,
+            BondlyColors.badgeCompetenciasEnd,
+          ],
+        );
+      case 1:
+        return const LinearGradient(
+          begin: Alignment.topRight,
+          end: Alignment.bottomLeft,
+          colors: [
+            BondlyColors.badgeEspecialesStart,
+            BondlyColors.badgeEspecialesEnd,
+          ],
+        );
+      case 2:
+        return const LinearGradient(
+          begin: Alignment.topRight,
+          end: Alignment.bottomLeft,
+          colors: [
+            BondlyColors.badgeValoresStart,
+            BondlyColors.badgeValoresEnd,
+          ],
+        );
+      default:
+        return const LinearGradient(
+          colors: [
+            BondlyColors.badgeCompetenciasStart,
+            BondlyColors.badgeCompetenciasEnd,
+          ],
+        );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +161,7 @@ class RecognizeTab extends StatelessWidget {
         children: [
           _buildSliderSection(),
           _buildAvisosSection(colors),
-          _buildPointsSection(),
+          _buildPointsSection(colors),
           const SizedBox(height: 20),
         ],
       ),
@@ -84,9 +224,9 @@ class RecognizeTab extends StatelessWidget {
     );
   }
 
-  // ─── Points Section ───────────────────────────────────────────────────
+  // ─── Points Section (dispatches per step) ─────────────────────────────
 
-  Widget _buildPointsSection() {
+  Widget _buildPointsSection(BondlyColorScheme colors) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(
         AppDimensions.paddingScreen,
@@ -94,36 +234,782 @@ class RecognizeTab extends StatelessWidget {
         AppDimensions.paddingScreen,
         0,
       ),
-      child: PointsCard(
-        value: model.user?.giftedPoints.toString() ?? '0',
-        valueLabel: StringsHome.pointsLabel,
-        description: StringsHome.pointsDescription,
-        subtitle: StringsHome.badgePickSubtitle,
-        badges: [
-          BadgeIconButton(
-            type: BadgeType.competencias,
-            label: StringsHome.badgeCompetencias,
-            onTap: () => _onBadgeTap(0),
-          ),
-          BadgeIconButton(
-            type: BadgeType.especiales,
-            label: StringsHome.badgeEspeciales,
-            onTap: () => _onBadgeTap(1),
-          ),
-          BadgeIconButton(
-            type: BadgeType.valores,
-            label: StringsHome.badgeValores,
-            onTap: () => _onBadgeTap(2),
-          ),
-        ],
+      child: Container(
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(AppDimensions.radiusCard),
+          border: Border.all(color: colors.border, width: 1),
+        ),
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          child: _buildCurrentStep(colors),
+        ),
       ),
     );
   }
 
-  void _onBadgeTap(int categoryIndex) {
-    final categories = model.categories.categories;
-    if (categories != null && categoryIndex < categories.length) {
-      model.selectedCategory = categories[categoryIndex].id;
+  Widget _buildCurrentStep(BondlyColorScheme colors) {
+    switch (_currentStep) {
+      case RecognizeStep.selectBadge:
+        return _buildStep1Content(colors);
+      case RecognizeStep.selectPerson:
+        return _buildStep2Content(colors);
+      case RecognizeStep.writeMessage:
+        return _buildStep3Content(colors);
     }
+  }
+
+  // ─── Step 1: Select Badge ─────────────────────────────────────────────
+
+  Widget _buildStep1Content(BondlyColorScheme colors) {
+    final categories = model.categories.categories ?? [];
+    final hasActiveCategory =
+        _activeCategoryIndex >= 0 && _activeCategoryIndex < categories.length;
+    final activeCategoryName = hasActiveCategory
+        ? categories[_activeCategoryIndex].name ?? ''
+        : StringsHome.badgePickSubtitle;
+
+    return Column(
+      key: const ValueKey('step1'),
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        // Points header
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: [
+            Text(
+              model.user?.giftedPoints.toString() ?? '0',
+              style: GoogleFonts.montserrat(
+                fontSize: 36,
+                fontWeight: FontWeight.w800,
+                color: colors.accent,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              StringsHome.pointsLabel,
+              style: GoogleFonts.montserrat(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: colors.textSecondary,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text(
+          StringsHome.pointsDescription,
+          textAlign: TextAlign.center,
+          style: GoogleFonts.montserrat(
+            fontSize: 13,
+            color: colors.textMuted,
+          ),
+        ),
+        const SizedBox(height: 20),
+        Divider(color: colors.border, height: 1),
+        const SizedBox(height: 14),
+
+        // Active category name
+        Text(
+          activeCategoryName,
+          textAlign: TextAlign.center,
+          style: GoogleFonts.montserrat(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: colors.textSecondary,
+          ),
+        ),
+        const SizedBox(height: 14),
+
+        // 3 badge categories
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: List.generate(
+            categories.length > 3 ? 3 : categories.length,
+            (index) {
+              final isActive = index == _activeCategoryIndex;
+              final badgeType = _badgeTypeForIndex(index);
+              return GestureDetector(
+                onTap: () {
+                  setState(() => _activeCategoryIndex = index);
+                  model.selectedCategory = categories[index].id;
+                },
+                child: AnimatedOpacity(
+                  duration: const Duration(milliseconds: 200),
+                  opacity: isActive || !hasActiveCategory ? 1.0 : 0.35,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Container(
+                        width: 62,
+                        height: 62,
+                        decoration: isActive
+                            ? BoxDecoration(
+                                shape: BoxShape.circle,
+                                border: Border.all(
+                                  color: colors.accent,
+                                  width: 2.5,
+                                ),
+                                boxShadow: [
+                                  BoxShadow(
+                                    color:
+                                        colors.accent.withValues(alpha: 0.3),
+                                    blurRadius: 12,
+                                    spreadRadius: 1,
+                                  ),
+                                ],
+                              )
+                            : null,
+                        child: Center(
+                          child: Container(
+                            width: 56,
+                            height: 56,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              gradient:
+                                  _gradientForCategoryIndex(index),
+                            ),
+                            child: Icon(
+                              _defaultIconForBadgeType(badgeType),
+                              size: 26,
+                              color: BondlyColors.white,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        _categoryLabelForIndex(index),
+                        style: GoogleFonts.montserrat(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                          color: colors.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        if (hasActiveCategory) ...[
+          const SizedBox(height: 14),
+          Divider(color: colors.border, height: 1),
+          const SizedBox(height: 14),
+
+          // "Elige una insignia" label
+          Text(
+            StringsHome.step1ChooseBadge,
+            style: GoogleFonts.montserrat(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: colors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 14),
+
+          // Sub-badge grid
+          if (model.loadingBadges)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 20),
+              child: Center(child: CircularProgressIndicator()),
+            )
+          else
+            Wrap(
+              spacing: 16,
+              runSpacing: 16,
+              alignment: WrapAlignment.center,
+              children: model.badges.badges.map((badge) {
+                return _buildBadgeItem(badge, colors);
+              }).toList(),
+            ),
+        ],
+
+        const SizedBox(height: 16),
+
+        // Cost info row
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(LucideIcons.info, size: 14, color: colors.textMuted),
+            const SizedBox(width: 6),
+            Text(
+              StringsHome.step1BadgeCostInfo,
+              style: GoogleFonts.montserrat(
+                fontSize: 11,
+                color: colors.textMuted,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBadgeItem(Badge badge, BondlyColorScheme colors) {
+    return GestureDetector(
+      onTap: () {
+        model.selectedBadge = badge;
+        _goToStep(RecognizeStep.selectPerson);
+      },
+      child: SizedBox(
+        width: 64,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: colors.accentGradientStart.withValues(alpha: 0.09),
+              ),
+              child: badge.image != null && badge.image!.isNotEmpty
+                  ? ClipOval(
+                      child: Image.network(
+                        badge.image!,
+                        width: 48,
+                        height: 48,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, __, ___) => Icon(
+                          LucideIcons.award,
+                          size: 24,
+                          color: colors.accent,
+                        ),
+                      ),
+                    )
+                  : Icon(
+                      LucideIcons.award,
+                      size: 24,
+                      color: colors.accent,
+                    ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              badge.name ?? '',
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: GoogleFonts.montserrat(
+                fontSize: 10,
+                color: colors.textSecondary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ─── Step 2: Select Person ────────────────────────────────────────────
+
+  Widget _buildStep2Content(BondlyColorScheme colors) {
+    final currentUserId = model.user?.id;
+    final collaboratorsWithoutSelf = model.collaboratorsList.where((c) {
+      final userId = c['user_id'] as String? ?? '';
+      return userId != currentUserId;
+    }).toList();
+    final filteredCollaborators = _searchQuery.isEmpty
+        ? collaboratorsWithoutSelf
+        : collaboratorsWithoutSelf.where((c) {
+            final name = (c['display'] as String? ?? '').toLowerCase();
+            return name.contains(_searchQuery.toLowerCase());
+          }).toList();
+
+    return Column(
+      key: const ValueKey('step2'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header row with points + cancel
+        _buildStepHeader(colors, onCancel: _resetToStep1),
+        const SizedBox(height: 12),
+
+        // Badge chip
+        _buildBadgeChip(colors, onTap: _resetToStep1),
+        const SizedBox(height: 14),
+        Divider(color: colors.border, height: 1),
+        const SizedBox(height: 14),
+
+        // "A quién quieres reconocer?" label
+        Text(
+          StringsHome.step2SearchLabel,
+          style: GoogleFonts.montserrat(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: colors.textSecondary,
+          ),
+        ),
+        const SizedBox(height: 10),
+
+        // Search field
+        Container(
+          decoration: BoxDecoration(
+            color: colors.surfaceElevated,
+            borderRadius: BorderRadius.circular(AppDimensions.radiusPill),
+            border: Border.all(color: colors.border, width: 1),
+          ),
+          child: TextField(
+            controller: _searchController,
+            onChanged: (value) {
+              _debounceTimer?.cancel();
+              _debounceTimer = Timer(const Duration(milliseconds: 300), () {
+                setState(() => _searchQuery = value);
+              });
+            },
+            style: GoogleFonts.montserrat(
+              fontSize: 13,
+              color: colors.textPrimary,
+            ),
+            decoration: InputDecoration(
+              hintText: StringsHome.step2SearchHint,
+              hintStyle: GoogleFonts.montserrat(
+                fontSize: 13,
+                color: colors.textMuted,
+              ),
+              prefixIcon: Icon(
+                LucideIcons.search,
+                size: 18,
+                color: colors.textMuted,
+              ),
+              border: InputBorder.none,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 12,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 10),
+
+        // Results list
+        if (filteredCollaborators.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 20),
+            child: Center(
+              child: Text(
+                StringsHome.step2NoResults,
+                style: GoogleFonts.montserrat(
+                  fontSize: 13,
+                  color: colors.textMuted,
+                ),
+              ),
+            ),
+          )
+        else
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 200),
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: filteredCollaborators.length,
+              itemBuilder: (context, index) {
+                final collaborator = filteredCollaborators[index];
+                return _buildCollaboratorItem(collaborator, colors);
+              },
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildCollaboratorItem(
+    Map<String, dynamic> collaborator,
+    BondlyColorScheme colors,
+  ) {
+    final name = collaborator['display'] as String? ?? '';
+    final avatar = collaborator['avatar'] as String? ?? '';
+    final userId = collaborator['user_id'] as String? ?? '';
+
+    return InkWell(
+      onTap: () {
+        setState(() => _selectedPerson = collaborator);
+        model.collaboratorsIds = [userId];
+        _goToStep(RecognizeStep.writeMessage);
+      },
+      borderRadius: BorderRadius.circular(AppDimensions.radiusPill),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+        child: Row(
+          children: [
+            CircleAvatar(
+              radius: 16,
+              backgroundImage: avatar.isNotEmpty ? NetworkImage(avatar) : null,
+              backgroundColor: colors.surfaceElevated,
+              child: avatar.isEmpty
+                  ? Icon(LucideIcons.user, size: 16, color: colors.textMuted)
+                  : null,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    name,
+                    style: GoogleFonts.montserrat(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                      color: colors.textPrimary,
+                    ),
+                  ),
+                  if (model.user?.companyName != null)
+                    Text(
+                      model.user!.companyName!,
+                      style: GoogleFonts.montserrat(
+                        fontSize: 11,
+                        color: colors.textMuted,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ─── Step 3: Write Message & Send ─────────────────────────────────────
+
+  Widget _buildStep3Content(BondlyColorScheme colors) {
+    final canSend = _messageController.text.trim().isNotEmpty &&
+        !model.creatingAcknowledgment;
+
+    return Column(
+      key: const ValueKey('step3'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header row with points + cancel
+        _buildStepHeader(colors, onCancel: _resetToStep1),
+        const SizedBox(height: 12),
+
+        // Badge chip
+        _buildBadgeChip(colors, onTap: _resetToStep1),
+        const SizedBox(height: 8),
+
+        // Person chip
+        _buildPersonChip(colors, onTap: _resetToStep2),
+        const SizedBox(height: 14),
+        Divider(color: colors.border, height: 1),
+        const SizedBox(height: 14),
+
+        // "Escribe tu reconocimiento" label
+        Text(
+          StringsHome.step3WriteLabel,
+          style: GoogleFonts.montserrat(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: colors.textSecondary,
+          ),
+        ),
+        const SizedBox(height: 10),
+
+        // Text area
+        Container(
+          decoration: BoxDecoration(
+            color: colors.surfaceElevated,
+            borderRadius: BorderRadius.circular(AppDimensions.radiusPill),
+            border: Border.all(color: colors.border, width: 1),
+          ),
+          child: TextField(
+            controller: _messageController,
+            maxLength: 150,
+            maxLines: 3,
+            style: GoogleFonts.montserrat(
+              fontSize: 13,
+              color: colors.textPrimary,
+            ),
+            decoration: InputDecoration(
+              hintText: StringsHome.step3WriteLabel,
+              hintStyle: GoogleFonts.montserrat(
+                fontSize: 13,
+                color: colors.textMuted,
+              ),
+              border: InputBorder.none,
+              counterText: '',
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 12,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+
+        // Char counter
+        Align(
+          alignment: Alignment.centerRight,
+          child: Text(
+            '${_messageController.text.length}/150',
+            style: GoogleFonts.montserrat(
+              fontSize: 11,
+              color: colors.textMuted,
+            ),
+          ),
+        ),
+        const SizedBox(height: 14),
+
+        // Send button
+        AnimatedOpacity(
+          duration: const Duration(milliseconds: 200),
+          opacity: canSend ? 1.0 : 0.5,
+          child: GestureDetector(
+            onTap: canSend ? _handleSend : null,
+            child: Container(
+              width: double.infinity,
+              height: 48,
+              decoration: BoxDecoration(
+                gradient: AppDimensions.accentGradient(colors),
+                borderRadius: BorderRadius.circular(AppDimensions.radiusPill),
+                boxShadow: [
+                  BoxShadow(
+                    color: colors.accent.withValues(alpha: 0.3),
+                    blurRadius: 8,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  if (model.creatingAcknowledgment)
+                    const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: BondlyColors.white,
+                      ),
+                    )
+                  else ...[
+                    const Icon(
+                      LucideIcons.send,
+                      size: 18,
+                      color: BondlyColors.white,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      StringsHome.step3SendButton,
+                      style: GoogleFonts.montserrat(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                        color: BondlyColors.white,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _handleSend() async {
+    final success =
+        await model.submitAcknowledgmentDirect(_messageController.text);
+    if (!mounted) return;
+    if (success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(StringsHome.acknowledgmentSuccess)),
+      );
+      _resetToStep1();
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(StringsHome.acknowledgmentError)),
+      );
+    }
+  }
+
+  // ─── Shared Widgets ───────────────────────────────────────────────────
+
+  Widget _buildStepHeader(BondlyColorScheme colors,
+      {required VoidCallback onCancel}) {
+    return Row(
+      children: [
+        Expanded(child: _buildCompactPointsHeader(colors)),
+        GestureDetector(
+          onTap: onCancel,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(LucideIcons.x, size: 14, color: colors.textMuted),
+              const SizedBox(width: 4),
+              Text(
+                'Cancelar',
+                style: GoogleFonts.montserrat(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: colors.textMuted,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCompactPointsHeader(BondlyColorScheme colors) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.baseline,
+      textBaseline: TextBaseline.alphabetic,
+      children: [
+        Text(
+          model.user?.giftedPoints.toString() ?? '0',
+          style: GoogleFonts.montserrat(
+            fontSize: 24,
+            fontWeight: FontWeight.w800,
+            color: colors.accent,
+          ),
+        ),
+        const SizedBox(width: 6),
+        Text(
+          StringsHome.pointsLabel,
+          style: GoogleFonts.montserrat(
+            fontSize: 13,
+            fontWeight: FontWeight.w500,
+            color: colors.textSecondary,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBadgeChip(BondlyColorScheme colors, {VoidCallback? onTap}) {
+    final badge = model.selectedBadge;
+    if (badge == null) return const SizedBox.shrink();
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: colors.accentSoft,
+          borderRadius: BorderRadius.circular(AppDimensions.radiusPill),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: _gradientForCategoryIndex(_activeCategoryIndex),
+              ),
+              child: badge.image != null && badge.image!.isNotEmpty
+                  ? ClipOval(
+                      child: Image.network(
+                        badge.image!,
+                        width: 36,
+                        height: 36,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, __, ___) => const Icon(
+                          LucideIcons.award,
+                          size: 18,
+                          color: BondlyColors.white,
+                        ),
+                      ),
+                    )
+                  : const Icon(
+                      LucideIcons.award,
+                      size: 18,
+                      color: BondlyColors.white,
+                    ),
+            ),
+            const SizedBox(width: 10),
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    badge.name ?? '',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: colors.textPrimary,
+                    ),
+                  ),
+                  Text(
+                    _categoryLabelForIndex(_activeCategoryIndex),
+                    style: GoogleFonts.montserrat(
+                      fontSize: 11,
+                      color: colors.textMuted,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Icon(LucideIcons.check, size: 16, color: colors.accent),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPersonChip(BondlyColorScheme colors, {VoidCallback? onTap}) {
+    if (_selectedPerson == null) return const SizedBox.shrink();
+
+    final name = _selectedPerson!['display'] as String? ?? '';
+    final avatar = _selectedPerson!['avatar'] as String? ?? '';
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: colors.accentSoft,
+          borderRadius: BorderRadius.circular(AppDimensions.radiusPill),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircleAvatar(
+              radius: 18,
+              backgroundImage:
+                  avatar.isNotEmpty ? NetworkImage(avatar) : null,
+              backgroundColor: colors.surfaceElevated,
+              child: avatar.isEmpty
+                  ? Icon(LucideIcons.user, size: 18, color: colors.textMuted)
+                  : null,
+            ),
+            const SizedBox(width: 10),
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    name,
+                    style: GoogleFonts.montserrat(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: colors.textPrimary,
+                    ),
+                  ),
+                  if (model.user?.companyName != null)
+                    Text(
+                      model.user!.companyName!,
+                      style: GoogleFonts.montserrat(
+                        fontSize: 11,
+                        color: colors.textMuted,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Icon(LucideIcons.check, size: 16, color: colors.accent),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/home/ui/screens/tab_recognize.dart
+++ b/lib/features/home/ui/screens/tab_recognize.dart
@@ -6,6 +6,7 @@ import 'package:bondly_app/config/strings_home.dart';
 import 'package:bondly_app/features/home/domain/models/badge_model.dart';
 import 'package:bondly_app/features/home/ui/viewmodels/home_viewmodel.dart';
 import 'package:bondly_app/ui/shared/badge_icon_button.dart' show BadgeType;
+import 'package:bondly_app/ui/shared/bondly_skeleton.dart';
 import 'package:bondly_app/ui/shared/info_card.dart';
 import 'package:bondly_app/ui/shared/slider_banner_card.dart';
 import 'package:flutter/material.dart' hide Badge;
@@ -153,9 +154,12 @@ class _RecognizeTabState extends State<RecognizeTab> {
     }
   }
 
+  bool get _isLoading => model.user == null;
+
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<BondlyColorScheme>()!;
+    if (_isLoading) return _buildSkeletonState(colors);
     return SingleChildScrollView(
       child: Column(
         children: [
@@ -164,6 +168,97 @@ class _RecognizeTabState extends State<RecognizeTab> {
           _buildPointsSection(colors),
           const SizedBox(height: 20),
         ],
+      ),
+    );
+  }
+
+  // ─── Skeleton Loading State ─────────────────────────────────────────
+
+  Widget _buildSkeletonState(BondlyColorScheme colors) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.paddingScreen,
+        ),
+        child: Column(
+          children: [
+            const SizedBox(height: 8),
+            // Slider banner placeholder
+            const BondlyShimmerBlock(
+              width: double.infinity,
+              height: 160,
+              borderRadius: 16,
+            ),
+            const SizedBox(height: 12),
+            // Avisos card placeholder
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: colors.surface,
+                borderRadius:
+                    BorderRadius.circular(AppDimensions.radiusCard),
+                border: Border.all(color: colors.border, width: 1),
+              ),
+              child: const Row(
+                children: [
+                  BondlyShimmerCircle(size: 32),
+                  SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        BondlyShimmerBlock(width: 80, height: 12),
+                        SizedBox(height: 8),
+                        BondlyShimmerBlock(
+                          width: double.infinity,
+                          height: 10,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            // Points card placeholder
+            Container(
+              padding: const EdgeInsets.all(24),
+              decoration: BoxDecoration(
+                color: colors.surface,
+                borderRadius:
+                    BorderRadius.circular(AppDimensions.radiusCard),
+                border: Border.all(color: colors.border, width: 1),
+              ),
+              child: Column(
+                children: [
+                  // Points value
+                  const BondlyShimmerBlock(width: 100, height: 32),
+                  const SizedBox(height: 6),
+                  const BondlyShimmerBlock(width: 180, height: 12),
+                  const SizedBox(height: 20),
+                  Divider(color: colors.border, height: 1),
+                  const SizedBox(height: 14),
+                  // Subtitle
+                  const BondlyShimmerBlock(width: 140, height: 12),
+                  const SizedBox(height: 16),
+                  // 3 category circles
+                  const Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      _CategoryCircleSkeleton(),
+                      _CategoryCircleSkeleton(),
+                      _CategoryCircleSkeleton(),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  // Cost info row
+                  const BondlyShimmerBlock(width: 200, height: 10),
+                ],
+              ),
+            ),
+            const SizedBox(height: 20),
+          ],
+        ),
       ),
     );
   }
@@ -810,17 +905,21 @@ class _RecognizeTabState extends State<RecognizeTab> {
   }
 
   Future<void> _handleSend() async {
-    final success =
-        await model.submitAcknowledgmentDirect(_messageController.text);
+    final personName = _selectedPerson?['display'] as String? ?? '';
+    final personId = _selectedPerson?['user_id'] as String? ?? '';
+    final taggedMessage =
+        '@[$personName]($personId) ${_messageController.text}';
+    final error =
+        await model.submitAcknowledgmentDirect(taggedMessage);
     if (!mounted) return;
-    if (success) {
+    if (error == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(StringsHome.acknowledgmentSuccess)),
       );
       _resetToStep1();
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(StringsHome.acknowledgmentError)),
+        SnackBar(content: Text(error)),
       );
     }
   }
@@ -1010,6 +1109,22 @@ class _RecognizeTabState extends State<RecognizeTab> {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _CategoryCircleSkeleton extends StatelessWidget {
+  const _CategoryCircleSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        BondlyShimmerCircle(size: 56),
+        SizedBox(height: 8),
+        BondlyShimmerBlock(width: 60, height: 10),
+      ],
     );
   }
 }

--- a/lib/features/home/ui/viewmodels/home_viewmodel.dart
+++ b/lib/features/home/ui/viewmodels/home_viewmodel.dart
@@ -368,11 +368,12 @@ class HomeViewModel extends NavigationModel {
     }
   }
 
-  Future<bool> submitAcknowledgmentDirect(String message) async {
+  /// Returns `null` on success, or the error message on failure.
+  Future<String?> submitAcknowledgmentDirect(String message) async {
     if (selectedBadge == null ||
         message.trim().isEmpty ||
         collaboratorsIds.isEmpty) {
-      return false;
+      return 'Datos incompletos';
     }
     creatingAcknowledgment = true;
     final result = await _createAcknowledgmentUseCase.invoke(
@@ -380,18 +381,18 @@ class HomeViewModel extends NavigationModel {
       message.trim(),
       collaboratorsIds,
     );
-    bool success = false;
+    String? errorMessage;
     result.when((s) {
-      success = true;
       getCompanyFeeds();
       collaboratorsIds = [];
       selectedCategory = null;
       selectedBadge = null;
     }, (error) {
       log.e(error.toString());
+      errorMessage = error.toString();
     });
     creatingAcknowledgment = false;
-    return success;
+    return errorMessage;
   }
 
   CarouselSliderController carouselController = CarouselSliderController();

--- a/lib/features/home/ui/viewmodels/home_viewmodel.dart
+++ b/lib/features/home/ui/viewmodels/home_viewmodel.dart
@@ -310,8 +310,7 @@ class HomeViewModel extends NavigationModel {
             return {
               "id": collaborator.id ?? "No Name",
               "display": collaborator.completeName ?? "No Name",
-              "avatar": collaborator.avatar ??
-                  "https://api.minimalavatars.com/avatar/random/png",
+              "avatar": collaborator.avatar ?? "",
               "user_id": collaborator.id ?? "No Id"
             };
           })
@@ -367,6 +366,32 @@ class HomeViewModel extends NavigationModel {
         }
       });
     }
+  }
+
+  Future<bool> submitAcknowledgmentDirect(String message) async {
+    if (selectedBadge == null ||
+        message.trim().isEmpty ||
+        collaboratorsIds.isEmpty) {
+      return false;
+    }
+    creatingAcknowledgment = true;
+    final result = await _createAcknowledgmentUseCase.invoke(
+      selectedBadge!.id!,
+      message.trim(),
+      collaboratorsIds,
+    );
+    bool success = false;
+    result.when((s) {
+      success = true;
+      getCompanyFeeds();
+      collaboratorsIds = [];
+      selectedCategory = null;
+      selectedBadge = null;
+    }, (error) {
+      log.e(error.toString());
+    });
+    creatingAcknowledgment = false;
+    return success;
   }
 
   CarouselSliderController carouselController = CarouselSliderController();

--- a/lib/src/api_calls_handler.dart
+++ b/lib/src/api_calls_handler.dart
@@ -13,11 +13,34 @@ import 'package:logger/logger.dart';
 const String jsonContentType = "application/json";
 const String formContentType = "application/x-www-form-urlencoded";
 
-class ServerErrorException implements Exception {}
+class ServerErrorException implements Exception {
+  final String? message;
+  ServerErrorException([this.message]);
+  @override
+  String toString() => message ?? 'ServerErrorException';
+}
 
-class ServiceNotFoundException implements Exception {}
+class ServiceNotFoundException implements Exception {
+  final String? message;
+  ServiceNotFoundException([this.message]);
+  @override
+  String toString() => message ?? 'ServiceNotFoundException';
+}
 
-class UnauthorizedException implements Exception {}
+class UnauthorizedException implements Exception {
+  final String? message;
+  UnauthorizedException([this.message]);
+  @override
+  String toString() => message ?? 'UnauthorizedException';
+}
+
+class ApiErrorException implements Exception {
+  final String message;
+  final int statusCode;
+  ApiErrorException(this.message, this.statusCode);
+  @override
+  String toString() => message;
+}
 
 enum Methods {
   POST,
@@ -87,13 +110,27 @@ abstract class CallsHandler {
     /// Log this response
     logResponse(response);
 
+    if (response.statusCode >= 200 && response.statusCode < 300) return;
+
+    String? apiMessage;
+    try {
+      final data = jsonDecode(response.body);
+      apiMessage = data['error'] as String?;
+    } catch (_) {}
+
     switch (response.statusCode) {
       case 403:
-        throw UnauthorizedException();
+        throw apiMessage != null
+            ? ApiErrorException(apiMessage, 403)
+            : UnauthorizedException();
       case 404:
-        throw ServiceNotFoundException();
+        throw ServiceNotFoundException(apiMessage);
       case >= 500:
-        throw ServerErrorException();
+        throw ServerErrorException(apiMessage);
+      default:
+        if (apiMessage != null) {
+          throw ApiErrorException(apiMessage, response.statusCode);
+        }
     }
   }
 


### PR DESCRIPTION
## Summary                                                                                
                                                                                           
  - 3-step recognition flow in Reconocer tab: Replaced the static PointsCard with a full   
  interactive flow — Select Badge → Select Person → Write Message & Send — all within the
  same points section container using AnimatedSwitcher crossfade transitions
  - API error propagation: Added ApiErrorException to the API handler so backend error
  messages (e.g. "Ya reconociste a este usuario en el mes") reach the UI instead of showing
   a generic error
  - Fix pull-to-refresh in Feed tab: Added AlwaysScrollableScrollPhysics to both ListView
  instances so RefreshIndicator triggers even when content fits the viewport
  - Remove dead avatar fallback URL: Replaced unreachable api.minimalavatars.com fallback
  with empty string; UI already handles missing avatars with a user icon
  - Skeleton loading state: Added shimmer skeleton for the Reconocer tab that mirrors its
  layout (banner, avisos, points card with category circles)

 ## Changed files

  File: lib/config/strings_home.dart
  Change: Added 9 string constants for the 3-step flow
  ────────────────────────────────────────
  File: lib/features/home/ui/screens/tab_recognize.dart
  Change: Converted to StatefulWidget with 3-step flow, cancel button, self-exclusion from
    collaborators list, user tagging on send, shimmer skeleton
  ────────────────────────────────────────
  File: lib/features/home/ui/viewmodels/home_viewmodel.dart
  Change: Added submitAcknowledgmentDirect() returning error message, removed dead avatar
    URL
  ────────────────────────────────────────
  File: lib/features/home/data/repositories/default_company_feeds_repository.dart
  Change: Propagate ApiErrorException instead of swallowing it
  ────────────────────────────────────────
  File: lib/src/api_calls_handler.dart
  Change: Added ApiErrorException, parse API error body in throwOnFailureCode
  ────────────────────────────────────────
  File: lib/features/home/ui/screens/tab_feed.dart
  Change: Added AlwaysScrollableScrollPhysics to fix pull-to-refresh

##  Test plan

  - Step 1: tap a category → badges load → tap a badge → advances to step 2
  - Step 2: current user is NOT in the collaborators list → search works → tap a person →
  advances to step 3
  - Step 3: type message → send → success snackbar → resets to step 1
  - Cancel button on steps 2/3 resets flow back to step 1
  - Chip taps navigate back to the correct step
  - Send to already-recognized user shows API error message ("Ya reconociste a este usuario
   en el mes")
  - Pull-to-refresh on Feed tab triggers data reload (visible in logs)
  - Collaborators without avatars show user icon (no network error)
  - Skeleton loading state appears briefly on first load
  - Light and dark theme render correctly

## Evicende

|First Step | Second Step | Third Step | Error |
|---|---|---|---|
|<img width="563" height="1256" alt="image" src="https://github.com/user-attachments/assets/4c466597-625e-45ef-8063-948f9d4f6269" />|<img width="563" height="1256" alt="image" src="https://github.com/user-attachments/assets/efa945a4-e839-4a14-b02a-ff439fc0abeb" />|<img width="563" height="1256" alt="image" src="https://github.com/user-attachments/assets/e7f64cd7-4ef1-493f-9761-1285115116fe" />|<img width="563" height="1256" alt="image" src="https://github.com/user-attachments/assets/417a40bb-a122-4cdd-90b0-b315ffb49075" />|
