### PR TITLE
[FEAT] Rewards UI update

### DIFF
--- a/lib/config/strings_cart.dart
+++ b/lib/config/strings_cart.dart
@@ -11,4 +11,21 @@ class StringsCart {
       "No tienes suficientes puntos para canjear este producto";
   static const String goToRewards = 'Ir a Recompensas';
   static const String total = 'Total';
+
+  // Rewards screen
+  static const String selectItem = 'Seleccionar';
+  static const String noRewardsAvailable = 'No hay recompensas disponibles';
+  static const String validityPrefix = 'Vigencia:';
+  static const String pointsSuffix = 'pts';
+  static const String availableBalance = 'disponibles';
+  static const String checkoutSuccess =
+      "¡Felicidades! Has canjeado tus puntos exitosamente! El departamento de RR.HH. Se pondrá en contacto contigo.";
+  static const String checkoutError =
+      "¡Lo sentimos! No se pudo procesar tu solicitud. Por favor intenta de nuevo.";
+
+  // Reward categories
+  static const String categoryAll = 'Todos';
+  static const String categoryExperiences = 'Experiencias';
+  static const String categoryGiftCards = 'Gift Cards';
+  static const String categoryIncentives = 'Incentivos';
 }

--- a/lib/config/strings_profile.dart
+++ b/lib/config/strings_profile.dart
@@ -1,9 +1,9 @@
 class StringsProfile {
   static const String profileTitle = "Perfil";
   static const String defaultUser = "bienvenido";
-  static const String receivedPoints = "Puntos\nrecibidos";
+  static const String receivedPoints = "Puntos\nacumulados";
   static const String givenPoints = "Puntos\npara dar";
-  static const String monthlyPoints = "Puntos\ndel mes";
+  static const String spendablePoints = "Puntos\npara gastar";
   static const String closeSession = "Cerrar sesión";
   static const String myActivity = "Mi actividad";
   static const String monthlyReport = "Estado de cuenta";

--- a/lib/dependencies/viewmodel_provider.dart
+++ b/lib/dependencies/viewmodel_provider.dart
@@ -41,6 +41,7 @@ import 'package:bondly_app/features/profile/ui/viewmodels/my_rewards_viewmodel.d
 import 'package:bondly_app/features/profile/ui/viewmodels/profile_viewmodel.dart';
 import 'package:bondly_app/src/app_services.dart';
 import 'package:bondly_app/src/routes.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class ViewModelProvider {
   static void provide() {
@@ -56,6 +57,7 @@ class ViewModelProvider {
         logoutUseCase: getIt<LogoutUseCase>(),
         updateUserUseCase: getIt<UpdateUserAvatarUseCase>(),
         profileUseCase: getIt<UserProfileUseCase>(),
+        getAccountStatementUseCase: getIt<GetAccountStatementUseCase>(),
       ),
     );
 
@@ -106,6 +108,8 @@ class ViewModelProvider {
         getIt<PullCartItemUseCase>(),
         getIt<CheckOutCartUseCase>(),
         getIt<AppServices>(),
+        getIt<GetAccountStatementUseCase>(),
+        getIt<SharedPreferences>(),
       ),
     );
 

--- a/lib/features/profile/ui/screens/my_rewards_screen.dart
+++ b/lib/features/profile/ui/screens/my_rewards_screen.dart
@@ -1,19 +1,20 @@
+import 'package:bondly_app/config/colors.dart';
 import 'package:bondly_app/config/dimensions.dart';
-import 'package:bondly_app/config/theme.dart';
+import 'package:bondly_app/config/strings_cart.dart';
+import 'package:bondly_app/config/strings_profile.dart';
 import 'package:bondly_app/dependencies/dependency_manager.dart';
 import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
 import 'package:bondly_app/features/home/ui/widgets/full_screen_image.dart';
-import 'package:bondly_app/features/home/ui/widgets/gold_bordered_container.dart';
 import 'package:bondly_app/features/profile/domain/models/cart_model.dart';
 import 'package:bondly_app/features/profile/ui/screens/shopping_cart_screen.dart';
 import 'package:bondly_app/features/profile/ui/viewmodels/my_rewards_viewmodel.dart';
-import 'package:bondly_app/ui/shared/app_sliver_layout.dart';
 import 'package:bondly_app/src/network_image_helpers.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:bondly_app/ui/shared/bondly_skeleton.dart';
-import 'package:ficonsax/ficonsax.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:lucide_icons/lucide_icons.dart';
 
 class MyRewardsScreen extends StatefulWidget {
   static const String route = "/myRewardsScreen";
@@ -26,7 +27,9 @@ class MyRewardsScreen extends StatefulWidget {
 
 class _MyRewardsScreenState extends State<MyRewardsScreen> {
   late MyRewardsViewModel model;
-  bool isLoading = false;
+  int _selectedCategoryIndex = 0;
+  bool _isSendingCart = false;
+
   @override
   void initState() {
     model = getIt<MyRewardsViewModel>();
@@ -35,349 +38,612 @@ class _MyRewardsScreenState extends State<MyRewardsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    Size size = MediaQuery.of(context).size;
+    final colors = Theme.of(context).extension<BondlyColorScheme>()!;
+
     return ModelProvider<MyRewardsViewModel>(
       model: model,
       child: ModelBuilder<MyRewardsViewModel>(
-          builder: (context, rewardsModel, child) {
-        return BondlySliverLayout(
-            title: "Recompensas",
-            floatingActionButton: FloatingActionButton(
-              isExtended: true,
-              onPressed: () async {
-                final navigator = GoRouter.of(context);
-                if (!rewardsModel.cartEdited) {
-                  navigator.push(MyCartScreen.route);
-                  return;
-                }
-                setState(() {
-                  isLoading = true;
-                });
+        builder: (context, rewardsModel, child) {
+          return Scaffold(
+            backgroundColor: colors.bg,
+            body: Stack(
+              children: [
+                Column(
+                  children: [
+                    _buildHeader(rewardsModel, colors),
+                    _buildCategoryTabs(rewardsModel, colors),
+                    Expanded(
+                      child: rewardsModel.rewardList.rewards!.isEmpty
+                          ? _buildSkeletonState(colors)
+                          : rewardsModel.busy
+                              ? _buildSkeletonState(colors)
+                              : _buildRewardsList(rewardsModel, colors),
+                    ),
+                  ],
+                ),
+                Positioned(
+                  bottom: 20,
+                  right: 20,
+                  child: _buildCartFAB(rewardsModel, colors),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
 
-                await rewardsModel.sendItemsToCart();
-                if (!mounted) return;
-                setState(() {
-                  isLoading = false;
-                });
-                navigator.push(MyCartScreen.route);
-              },
-              tooltip: "Carrito",
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Icon(IconsaxOutline.shopping_cart),
-                  const SizedBox(
-                    width: 5,
+  Widget _buildHeader(
+    MyRewardsViewModel rewardsModel,
+    BondlyColorScheme colors,
+  ) {
+    return SafeArea(
+      bottom: false,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.paddingScreen,
+          vertical: AppDimensions.spacingSm,
+        ),
+        child: Row(
+          children: [
+            GestureDetector(
+              onTap: () => context.pop(),
+              child: Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: colors.surfaceElevated,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  LucideIcons.arrowLeft,
+                  size: 20,
+                  color: colors.textPrimary,
+                ),
+              ),
+            ),
+            Expanded(
+              child: Text(
+                StringsProfile.rewards,
+                textAlign: TextAlign.center,
+                style: GoogleFonts.montserrat(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w700,
+                  color: colors.textPrimary,
+                ),
+              ),
+            ),
+            if (rewardsModel.userBalance != null)
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
+                decoration: BoxDecoration(
+                  gradient: AppDimensions.accentGradient(colors),
+                  borderRadius:
+                      BorderRadius.circular(AppDimensions.radiusPill),
+                ),
+                child: Text(
+                  '${rewardsModel.userBalance} ${StringsCart.pointsSuffix}',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.white,
                   ),
-                  AnimatedOpacity(
-                    opacity: isLoading ? 0.4 : 1.0,
-                    duration: const Duration(milliseconds: 300),
-                    child: Text(
-                      "${rewardsModel.cartItems.length}",
-                      style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              )
+            else
+              const SizedBox(width: 40),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCategoryTabs(
+    MyRewardsViewModel rewardsModel,
+    BondlyColorScheme colors,
+  ) {
+    return SizedBox(
+      height: 48,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: rewardsModel.rewardCategories.length,
+        itemBuilder: (context, index) {
+          final isActive = _selectedCategoryIndex == index;
+          return Padding(
+            padding: EdgeInsets.only(
+              left: index == 0
+                  ? AppDimensions.paddingScreen
+                  : AppDimensions.spacingSm,
+              right: index == rewardsModel.rewardCategories.length - 1
+                  ? AppDimensions.paddingScreen
+                  : 0,
+            ),
+            child: GestureDetector(
+              onTap: () {
+                setState(() {
+                  _selectedCategoryIndex = index;
+                });
+                rewardsModel.filterByCategory(
+                  rewardsModel.rewardCategories[index],
+                );
+              },
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                decoration: BoxDecoration(
+                  gradient: isActive
+                      ? AppDimensions.accentGradient(colors)
+                      : null,
+                  color: isActive ? null : colors.surfaceElevated,
+                  border: isActive
+                      ? null
+                      : Border.all(color: colors.border, width: 1),
+                  borderRadius:
+                      BorderRadius.circular(AppDimensions.radiusPill),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  rewardsModel.rewardCategories[index],
+                  style: GoogleFonts.montserrat(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: isActive ? Colors.white : colors.textSecondary,
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildRewardsList(
+    MyRewardsViewModel rewardsModel,
+    BondlyColorScheme colors,
+  ) {
+    final rewards = rewardsModel.rewardList.rewards!;
+
+    if (rewards.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(LucideIcons.gift, size: 48, color: colors.textMuted),
+            const SizedBox(height: 12),
+            Text(
+              StringsCart.noRewardsAvailable,
+              style: GoogleFonts.montserrat(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: colors.textMuted,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.fromLTRB(
+        AppDimensions.paddingScreen,
+        12,
+        AppDimensions.paddingScreen,
+        100,
+      ),
+      physics: const AlwaysScrollableScrollPhysics(),
+      itemCount: rewards.length,
+      itemBuilder: (context, index) {
+        return _buildRewardCard(rewards[index], rewardsModel, colors);
+      },
+    );
+  }
+
+  void _handleAddToCart(MyRewardsViewModel rewardsModel, String rewardId) {
+    rewardsModel.cartEdited = true;
+    final added = rewardsModel.addToCart(rewardId);
+    if (!added) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(StringsCart.notEnoughPoints),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
+  Widget _buildRewardCard(
+    Reward reward,
+    MyRewardsViewModel rewardsModel,
+    BondlyColorScheme colors,
+  ) {
+    final itemCount = rewardsModel.getItemCount(reward.id);
+    final canAfford = rewardsModel.canAffordItem(reward.id);
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        border: Border.all(color: colors.border, width: 1),
+        borderRadius: BorderRadius.circular(AppDimensions.radiusCard),
+        boxShadow: AppDimensions.cardShadow(colors.textPrimary),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Card header row
+          Padding(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Icon(
+                  reward.enable == false
+                      ? LucideIcons.lock
+                      : LucideIcons.unlock,
+                  size: 18,
+                  color:
+                      reward.enable == false ? colors.textMuted : colors.accent,
+                ),
+                itemCount == 0
+                    ? GestureDetector(
+                        onTap: () =>
+                            _handleAddToCart(rewardsModel, reward.id),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 6,
+                          ),
+                          decoration: BoxDecoration(
+                            color: colors.accentSoft,
+                            borderRadius: BorderRadius.circular(
+                              AppDimensions.radiusPill,
+                            ),
+                          ),
+                          child: Text(
+                            StringsCart.selectItem,
+                            style: GoogleFonts.montserrat(
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                              color: colors.accent,
+                            ),
+                          ),
+                        ),
+                      )
+                    : Row(
+                        children: [
+                          GestureDetector(
+                            onTap: () {
+                              rewardsModel.cartEdited = true;
+                              rewardsModel.removeFromCart(reward.id);
+                            },
+                            child: Container(
+                              width: 28,
+                              height: 28,
+                              decoration: BoxDecoration(
+                                color: colors.surfaceElevated,
+                                shape: BoxShape.circle,
+                              ),
+                              child: Icon(
+                                LucideIcons.minus,
+                                size: 16,
+                                color: colors.textPrimary,
+                              ),
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                            ),
+                            child: Text(
+                              '$itemCount',
+                              style: GoogleFonts.montserrat(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w700,
+                                color: colors.textPrimary,
+                              ),
+                            ),
+                          ),
+                          GestureDetector(
+                            onTap: () =>
+                                _handleAddToCart(rewardsModel, reward.id),
+                            child: Container(
+                              width: 28,
+                              height: 28,
+                              decoration: BoxDecoration(
+                                color: colors.surfaceElevated,
+                                shape: BoxShape.circle,
+                              ),
+                              child: Icon(
+                                LucideIcons.plus,
+                                size: 16,
+                                color: colors.textPrimary,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+              ],
+            ),
+          ),
+
+          // Image section
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: GestureDetector(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => FullScreenImage(
+                      image: reward.image,
+                      tag: reward.id,
+                    ),
+                  ),
+                );
+              },
+              child: Hero(
+                tag: reward.id,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(
+                    AppDimensions.radiusCard - 4,
+                  ),
+                  child: AspectRatio(
+                    aspectRatio: 16 / 10,
+                    child: CachedNetworkImage(
+                      imageUrl: safeImageUrl(reward.imageUrl),
+                      fit: BoxFit.cover,
+                      placeholder: (context, url) =>
+                          const BondlyShimmerBlock(
+                        width: double.infinity,
+                        height: double.infinity,
+                        borderRadius: 12,
+                      ),
+                      errorWidget: (context, url, error) => Container(
+                        color: colors.surfaceElevated,
+                        child: Icon(
+                          LucideIcons.image,
+                          size: 40,
+                          color: colors.textMuted,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+
+          // Title + Points badge
+          Padding(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    reward.name,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: GoogleFonts.montserrat(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: colors.textPrimary,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: canAfford ? colors.accentSoft : Colors.red.shade50,
+                    borderRadius:
+                        BorderRadius.circular(AppDimensions.radiusPill),
+                  ),
+                  child: Text(
+                    '${reward.points} ${StringsCart.pointsSuffix}',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: canAfford ? colors.accent : Colors.red,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Divider
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Divider(
+              height: 0.5,
+              thickness: 0.5,
+              color: colors.border,
+            ),
+          ),
+
+          // Description
+          Padding(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Text(
+              reward.description,
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: GoogleFonts.montserrat(
+                fontSize: 13,
+                fontWeight: FontWeight.w400,
+                color: colors.textSecondary,
+              ),
+            ),
+          ),
+
+          // Validity row
+          if (reward.deadline != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+              child: Row(
+                children: [
+                  Icon(
+                    LucideIcons.calendar,
+                    size: 14,
+                    color: colors.textMuted,
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    '${StringsCart.validityPrefix} ${reward.deadline!.day.toString().padLeft(2, '0')}/${reward.deadline!.month.toString().padLeft(2, '0')}/${reward.deadline!.year}',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w400,
+                      color: colors.textMuted,
                     ),
                   ),
                 ],
               ),
             ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8.0),
-              child: rewardsModel.rewardList.rewards!.isEmpty
-                  ? const Center(
-                      child: BondlyShimmerBlock(
-                          width: 200, height: 200, borderRadius: 12),
-                    )
-                  : Column(
-                      children: [
-                        SizedBox(
-                          height: 50,
-                          child: rewardsModel.rewardList.rewards!.isEmpty
-                              ? const Center(
-                                  child: BondlyShimmerBlock(
-                                      width: double.infinity,
-                                      height: 40,
-                                      borderRadius: 20),
-                                )
-                              : ListView.builder(
-                                  scrollDirection: Axis.horizontal,
-                                  itemCount:
-                                      rewardsModel.rewardCategories.length,
-                                  itemBuilder: (context, index) {
-                                    return Padding(
-                                      padding: const EdgeInsets.symmetric(
-                                          horizontal: 8.0),
-                                      child: GestureDetector(
-                                        onTap: () {
-                                          rewardsModel.filterByCategory(
-                                              rewardsModel
-                                                  .rewardCategories[index]);
-                                        },
-                                        child: Chip(
-                                          label: Text(
-                                              rewardsModel
-                                                  .rewardCategories[index],
-                                              style: Theme.of(context)
-                                                  .textTheme
-                                                  .bodyMedium
-                                                  ?.copyWith(
-                                                      color: Theme.of(context)
-                                                          .colorScheme
-                                                          .tertiary)),
-                                        ),
-                                      ),
-                                    );
-                                  },
-                                ),
-                        ),
-                        const SizedBox(
-                          height: 10,
-                        ),
-                        rewardsModel.busy
-                            ? const Expanded(
-                                child: Center(
-                                  child: BondlyShimmerBlock(
-                                      width: 200,
-                                      height: 200,
-                                      borderRadius: 12),
-                                ),
-                              )
-                            : Expanded(
-                                child: ListView.builder(
-                                    itemCount:
-                                        rewardsModel.rewardList.rewards?.length,
-                                    itemBuilder: (context, index) {
-                                      Reward reward = rewardsModel
-                                          .rewardList.rewards![index];
-                                      return Container(
-                                        margin:
-                                            const EdgeInsets.only(bottom: 10),
-                                        child: GoldBorderedContainer(
-                                          child: Column(
-                                            children: [
-                                              RewardCardHeader(
-                                                reward: reward,
-                                                size: size,
-                                                rewardsModel: rewardsModel,
-                                              ),
-                                              const SizedBox(
-                                                height: 10,
-                                              ),
-                                              RewardCardImage(reward: reward),
-                                              const SizedBox(
-                                                height: 10,
-                                              ),
-                                              RewardCardTitleSection(
-                                                  reward: reward),
-                                              const Divider(),
-                                              RewardDescriptionCardSection(
-                                                  reward: reward),
-                                              const Divider(),
-                                              RewardFooterCardSection(
-                                                  reward: reward),
-                                            ],
-                                          ),
-                                        ),
-                                      );
-                                    }),
-                              ),
-                      ],
-                    ),
-            ));
-      }),
-    );
-  }
-}
-
-class RewardDescriptionCardSection extends StatelessWidget {
-  const RewardDescriptionCardSection({
-    super.key,
-    required this.reward,
-  });
-
-  final Reward reward;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Text(
-        reward.description,
-        style: Theme.of(context).textTheme.bodyMedium,
-      ),
-    );
-  }
-}
-
-class RewardFooterCardSection extends StatelessWidget {
-  const RewardFooterCardSection({
-    super.key,
-    required this.reward,
-  });
-
-  final Reward reward;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(8.0),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(AppDimensions.radiusSm),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(
-            "Vigencia",
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-          Text(
-            "${reward.deadline!.day}/${reward.deadline!.month}/${reward.deadline!.year}",
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
         ],
       ),
     );
   }
-}
 
-class RewardCardTitleSection extends StatelessWidget {
-  const RewardCardTitleSection({
-    super.key,
-    required this.reward,
-  });
-
-  final Reward reward;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Text(
-          " ${reward.name} ",
-          style: Theme.of(context).textTheme.titleMedium,
-        ),
-        const SizedBox(
-          width: 10,
-        ),
-        const SizedBox(
-          width: 5,
-        ),
-        Text(
-          "${reward.points} pts",
-          style: Theme.of(context).textTheme.titleMedium,
-        ),
-      ],
-    );
-  }
-}
-
-class RewardCardImage extends StatelessWidget {
-  const RewardCardImage({
-    super.key,
-    required this.reward,
-  });
-
-  final Reward reward;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => FullScreenImage(
-              image: reward.image,
-              tag: reward.id,
-            ),
+  Widget _buildSkeletonState(BondlyColorScheme colors) {
+    return ListView.builder(
+      padding: const EdgeInsets.fromLTRB(
+        AppDimensions.paddingScreen,
+        12,
+        AppDimensions.paddingScreen,
+        100,
+      ),
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: 3,
+      itemBuilder: (context, index) {
+        return Container(
+          margin: const EdgeInsets.only(bottom: 16),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: colors.surface,
+            borderRadius: BorderRadius.circular(AppDimensions.radiusCard),
+          ),
+          child: const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              BondlyShimmerBlock(
+                width: double.infinity,
+                height: 40,
+                borderRadius: 8,
+              ),
+              SizedBox(height: 12),
+              BondlyShimmerBlock(
+                width: double.infinity,
+                height: 160,
+                borderRadius: 12,
+              ),
+              SizedBox(height: 12),
+              BondlyShimmerBlock(
+                width: 200,
+                height: 16,
+                borderRadius: 8,
+              ),
+              SizedBox(height: 8),
+              BondlyShimmerBlock(
+                width: double.infinity,
+                height: 40,
+                borderRadius: 8,
+              ),
+            ],
           ),
         );
       },
-      child: Hero(
-        tag: reward.id,
-        child: AspectRatio(
-          aspectRatio: 1,
-          child: Container(
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(AppDimensions.radiusSm),
-              image: DecorationImage(
-                image: CachedNetworkImageProvider(
-                  safeImageUrl(reward.imageUrl),
-                ),
-                fit: BoxFit.cover,
-              ),
-            ),
-          ),
-        ),
-      ),
     );
   }
-}
 
-class RewardCardHeader extends StatelessWidget {
-  const RewardCardHeader({
-    super.key,
-    required this.reward,
-    required this.size,
-    required this.rewardsModel,
-  });
-
-  final Reward reward;
-  final Size size;
-  final MyRewardsViewModel rewardsModel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        Icon(
-            reward.enable == false
-                ? IconsaxOutline.lock
-                : IconsaxOutline.unlock,
-            color: Theme.of(context).colorScheme.tertiary),
-        SizedBox(width: size.width * .4),
-        //To be fixed, if item exist in cart, show the quantity and a + and - button to add or remove.
-        //If not, show a button to add to cart.
-        rewardsModel.getItemCount(reward.id) == 0
-            ? OutlinedButton(
-                onPressed: () {
-                  rewardsModel.cartEdited = true;
-                  rewardsModel.addToCart(reward.id);
-                },
-                child: const Text("Seleccionar"),
-              )
-            : Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  IconButton(
-                    onPressed: () {
-                      rewardsModel.cartEdited = true;
-                      rewardsModel.removeFromCart(reward.id);
-                    },
-                    icon: Icon(
-                      IconsaxOutline.minus,
-                      color: context.themeData.textTheme.bodyMedium?.color,
+  Widget _buildCartFAB(
+    MyRewardsViewModel rewardsModel,
+    BondlyColorScheme colors,
+  ) {
+    return GestureDetector(
+      onTap: () async {
+        final navigator = GoRouter.of(context);
+        if (!rewardsModel.cartEdited) {
+          navigator.push(MyCartScreen.route);
+          return;
+        }
+        setState(() {
+          _isSendingCart = true;
+        });
+        await rewardsModel.sendItemsToCart();
+        if (!mounted) return;
+        setState(() {
+          _isSendingCart = false;
+        });
+        navigator.push(MyCartScreen.route);
+      },
+      child: Container(
+        width: 56,
+        height: 56,
+        decoration: BoxDecoration(
+          gradient: AppDimensions.accentGradient(colors),
+          shape: BoxShape.circle,
+          boxShadow: AppDimensions.cardShadow(colors.textPrimary),
+        ),
+        child: Center(
+          child: _isSendingCart
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2.5,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+              : Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    const Icon(
+                      LucideIcons.shoppingCart,
+                      size: 24,
+                      color: Colors.white,
                     ),
-                  ),
-                  Text(
-                    '${rewardsModel.getItemCount(reward.id)}',
-                    style: Theme.of(context).textTheme.labelLarge,
-                  ),
-                  IconButton(
-                    onPressed: () {
-                      rewardsModel.cartEdited = true;
-                      rewardsModel.addToCart(reward.id);
-                    },
-                    icon: Icon(
-                      IconsaxOutline.add,
-                      color: context.themeData.textTheme.bodyMedium?.color,
-                    ),
-                  ),
-                ],
-              )
-      ],
+                    if (rewardsModel.cartItems.isNotEmpty)
+                      Positioned(
+                        top: -6,
+                        right: -8,
+                        child: Container(
+                          constraints: const BoxConstraints(
+                            minWidth: 18,
+                            minHeight: 18,
+                          ),
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                            color: colors.accentGradientEnd,
+                            shape: BoxShape.circle,
+                          ),
+                          child: Center(
+                            child: Text(
+                              '${rewardsModel.cartItems.length}',
+                              style: GoogleFonts.montserrat(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w700,
+                                color: Colors.white,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/profile/ui/screens/my_rewards_screen.dart
+++ b/lib/features/profile/ui/screens/my_rewards_screen.dart
@@ -53,11 +53,9 @@ class _MyRewardsScreenState extends State<MyRewardsScreen> {
                     _buildHeader(rewardsModel, colors),
                     _buildCategoryTabs(rewardsModel, colors),
                     Expanded(
-                      child: rewardsModel.rewardList.rewards!.isEmpty
+                      child: rewardsModel.busy
                           ? _buildSkeletonState(colors)
-                          : rewardsModel.busy
-                              ? _buildSkeletonState(colors)
-                              : _buildRewardsList(rewardsModel, colors),
+                          : _buildRewardsList(rewardsModel, colors),
                     ),
                   ],
                 ),

--- a/lib/features/profile/ui/screens/profile_screen.dart
+++ b/lib/features/profile/ui/screens/profile_screen.dart
@@ -373,8 +373,8 @@ class ProfileScreenState extends State<ProfileScreen> {
         const SizedBox(width: 12),
         Expanded(
           child: _StatCard(
-            value: _formatNumber(model.user?.monthlyPoints ?? 0),
-            label: StringsProfile.monthlyPoints,
+            value: _formatNumber(model.spendableBalance ?? 0),
+            label: StringsProfile.spendablePoints,
             colors: colors,
           ),
         ),

--- a/lib/features/profile/ui/viewmodels/my_rewards_viewmodel.dart
+++ b/lib/features/profile/ui/viewmodels/my_rewards_viewmodel.dart
@@ -1,9 +1,14 @@
+import 'dart:convert';
+
+import 'package:bondly_app/config/strings_cart.dart';
 import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
 import 'package:bondly_app/features/home/ui/screens/home_screen.dart';
+import 'package:bondly_app/features/profile/domain/models/account_statement_model.dart';
 import 'package:bondly_app/features/profile/domain/models/cart_model.dart';
 import 'package:bondly_app/features/profile/domain/models/rewards_list_model.dart';
 import 'package:bondly_app/features/profile/domain/usecases/bulk_add_cart_items_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/checkout_cart_usecase.dart';
+import 'package:bondly_app/features/profile/domain/usecases/get_account_statement_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/get_shopping_cart_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/get_shopping_items_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/pull_cart_item.usecase.dart';
@@ -12,6 +17,7 @@ import 'package:bondly_app/src/app_services.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:multiple_result/multiple_result.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class MyRewardsViewModel extends NavigationModel {
   Logger log = Logger(
@@ -23,9 +29,13 @@ class MyRewardsViewModel extends NavigationModel {
   final PushCartItemUseCase _pushCartItemUseCase;
   final PullCartItemUseCase _pullCartItemUseCase;
   final CheckOutCartUseCase _checkOutCartUseCase;
+  final GetAccountStatementUseCase _getAccountStatementUseCase;
+  final SharedPreferences _sharedPreferences;
 
   final GlobalKey<ScaffoldState> cartScaffoldKey = GlobalKey<ScaffoldState>();
   final AppServices snackBarService;
+
+  static const String _cartStorageKey = 'local_cart_items';
 
   MyRewardsViewModel(
       this._getShoppingItemsUseCase,
@@ -34,17 +44,67 @@ class MyRewardsViewModel extends NavigationModel {
       this._pushCartItemUseCase,
       this._pullCartItemUseCase,
       this._checkOutCartUseCase,
-      this.snackBarService) {
+      this.snackBarService,
+      this._getAccountStatementUseCase,
+      this._sharedPreferences) {
     log.i("MyRewardsViewModel Created");
     init();
   }
 
   Future<void> init() async {
-    Future.wait([
+    _loadCartFromLocal();
+    await Future.wait([
       handleGetUserCart(),
       handleGetRewards(),
+      handleGetBalance(),
     ]);
   }
+
+  // ── Balance state ──────────────────────────────────────────────────
+
+  int? _userBalance;
+  int? get userBalance => _userBalance;
+
+  Future<void> handleGetBalance() async {
+    Result<AccountStatement, Exception> result =
+        await _getAccountStatementUseCase.invoke();
+    result.when((statement) {
+      _userBalance = statement.balance;
+      log.i("### User balance fetched: $_userBalance");
+      notifyListeners();
+    }, (error) {
+      log.e("### Error fetching user balance: $error");
+    });
+  }
+
+  // ── Reward points map ──────────────────────────────────────────────
+
+  final Map<String, int> _rewardPointsMap = {};
+
+  // ── Cart total ─────────────────────────────────────────────────────
+
+  int get cartTotal {
+    int total = 0;
+    for (var item in _cartItems) {
+      if (item == null) continue;
+      final id = item['id'] as String?;
+      final qty = item['quantity'] as int? ?? 0;
+      if (id != null && _rewardPointsMap.containsKey(id)) {
+        total += _rewardPointsMap[id]! * qty;
+      }
+    }
+    return total;
+  }
+
+  // ── Affordability check ────────────────────────────────────────────
+
+  bool canAffordItem(String itemId) {
+    if (_userBalance == null) return true; // Allow if balance unknown
+    final itemPoints = _rewardPointsMap[itemId] ?? 0;
+    return cartTotal + itemPoints <= _userBalance!;
+  }
+
+  // ── Rewards list ───────────────────────────────────────────────────
 
   RewardList _rewardList = RewardList(rewards: []);
 
@@ -67,7 +127,7 @@ class MyRewardsViewModel extends NavigationModel {
   Future<void> filterByCategory(String category) async {
     busy = true;
     await handleGetRewards();
-    if (category == "Todos") {
+    if (category == StringsCart.categoryAll) {
       rewardList = RewardList(rewards: _rewardList.rewards);
     } else {
       List<Reward> filteredList = [];
@@ -89,7 +149,11 @@ class MyRewardsViewModel extends NavigationModel {
     notifyListeners();
   }
 
-  void addToCart(String itemId, {int? quantity}) {
+  bool addToCart(String itemId, {int? quantity, bool skipValidation = false}) {
+    if (!skipValidation && !canAffordItem(itemId)) {
+      return false;
+    }
+
     // Busca si el elemento ya está en el carrito
     final existingItem = _cartItems.firstWhere(
       (item) => item!['id'] == itemId,
@@ -105,7 +169,9 @@ class MyRewardsViewModel extends NavigationModel {
       _cartItems.add({'id': itemId, 'quantity': quantity ?? 1});
     }
 
+    _saveCartToLocal();
     notifyListeners();
+    return true;
   }
 
   void removeFromCart(String itemId) {
@@ -126,6 +192,7 @@ class MyRewardsViewModel extends NavigationModel {
         _cartItems.remove(existingItem);
       }
 
+      _saveCartToLocal();
       notifyListeners();
     }
   }
@@ -143,6 +210,11 @@ class MyRewardsViewModel extends NavigationModel {
     Result result = await _getShoppingItemsUseCase.invoke();
     result.when((rewards) {
       rewardList = rewards;
+
+      // Populate reward points map from the full list
+      for (var reward in (rewards as RewardList).rewards ?? []) {
+        _rewardPointsMap[reward.id] = reward.points;
+      }
     }, (error) {
       log.e(error);
     });
@@ -163,13 +235,15 @@ class MyRewardsViewModel extends NavigationModel {
     result.when((cart) {
       UserCart myCart = cart;
 
+      _cartItems = [];
       for (var originalElement in myCart.rewards) {
         log.i("Cart Item: ${originalElement.quantity.toString()}");
         addToCart(originalElement.reward.id,
-            quantity: originalElement.quantity);
+            quantity: originalElement.quantity, skipValidation: true);
       }
       log.i("User Cart: ${cart.id.toString()}");
       userCart = myCart;
+      _saveCartToLocal();
     }, (error) {
       log.e(error);
     });
@@ -191,6 +265,7 @@ class MyRewardsViewModel extends NavigationModel {
     Result result = await _bulkAddCartItemsUseCase.invoke(body, _userCart.id);
     result.when((cart) {
       userCart = cart;
+      _saveCartToLocal();
     }, (error) {
       log.e(error);
     });
@@ -210,10 +285,10 @@ class MyRewardsViewModel extends NavigationModel {
   }
 
   List<String> _rewardCategories = [
-    "Todos",
-    "Experiencias",
-    "Gift Cards",
-    "Incentivos"
+    StringsCart.categoryAll,
+    StringsCart.categoryExperiences,
+    StringsCart.categoryGiftCards,
+    StringsCart.categoryIncentives,
   ];
   List<String> get rewardCategories => _rewardCategories;
   set rewardCategories(List<String> categories) {
@@ -239,14 +314,13 @@ class MyRewardsViewModel extends NavigationModel {
     Result result = await _checkOutCartUseCase.invoke(_userCart.id);
     busy = false;
     result.when((success) {
+      _clearLocalCart();
       navigation.go(HomeScreen.route);
-      handleShowSnackBar(
-          "¡Felicidades! Has canjeado tus puntos exitosamente! 🎉 El departamento de RR.HH. Se pondrá en contacto contigo.");
+      handleShowSnackBar(StringsCart.checkoutSuccess);
       return true;
     }, (error) {
       log.e(error);
-      handleShowSnackBar(
-          "¡Lo sentimos! No se pudo procesar tu solicitud. Por favor intenta de nuevo.");
+      handleShowSnackBar(StringsCart.checkoutError);
       return false;
     });
     return true;
@@ -255,11 +329,32 @@ class MyRewardsViewModel extends NavigationModel {
   void handleResetAll() {
     _cartItems = [];
     _userCart = UserCart(rewards: []);
+    _clearLocalCart();
     notifyListeners();
   }
 
   void handleShowSnackBar(String message) {
     snackBarService.showSnackbar(cartScaffoldKey, message);
+  }
+
+  // ── Local cart persistence ─────────────────────────────────────────
+
+  void _saveCartToLocal() {
+    final encoded = jsonEncode(_cartItems);
+    _sharedPreferences.setString(_cartStorageKey, encoded);
+  }
+
+  void _loadCartFromLocal() {
+    final stored = _sharedPreferences.getString(_cartStorageKey);
+    if (stored != null) {
+      final decoded = jsonDecode(stored) as List<dynamic>;
+      _cartItems = decoded.map((e) => e as Map<String, dynamic>?).toList();
+      notifyListeners();
+    }
+  }
+
+  void _clearLocalCart() {
+    _sharedPreferences.remove(_cartStorageKey);
   }
 
   @override

--- a/lib/features/profile/ui/viewmodels/my_rewards_viewmodel.dart
+++ b/lib/features/profile/ui/viewmodels/my_rewards_viewmodel.dart
@@ -211,7 +211,7 @@ class MyRewardsViewModel extends NavigationModel {
     result.when((rewards) {
       rewardList = rewards;
 
-      // Populate reward points map from the full list
+      _rewardPointsMap.clear();
       for (var reward in (rewards as RewardList).rewards ?? []) {
         _rewardPointsMap[reward.id] = reward.points;
       }
@@ -313,17 +313,17 @@ class MyRewardsViewModel extends NavigationModel {
     busy = true;
     Result result = await _checkOutCartUseCase.invoke(_userCart.id);
     busy = false;
-    result.when((success) {
+    bool success = false;
+    result.when((_) {
       _clearLocalCart();
       navigation.go(HomeScreen.route);
       handleShowSnackBar(StringsCart.checkoutSuccess);
-      return true;
+      success = true;
     }, (error) {
       log.e(error);
       handleShowSnackBar(StringsCart.checkoutError);
-      return false;
     });
-    return true;
+    return success;
   }
 
   void handleResetAll() {
@@ -339,22 +339,35 @@ class MyRewardsViewModel extends NavigationModel {
 
   // ── Local cart persistence ─────────────────────────────────────────
 
-  void _saveCartToLocal() {
-    final encoded = jsonEncode(_cartItems);
-    _sharedPreferences.setString(_cartStorageKey, encoded);
+  Future<void> _saveCartToLocal() async {
+    try {
+      final encoded = jsonEncode(_cartItems);
+      await _sharedPreferences.setString(_cartStorageKey, encoded);
+    } catch (e) {
+      log.e("Failed to save cart locally: $e");
+    }
   }
 
   void _loadCartFromLocal() {
     final stored = _sharedPreferences.getString(_cartStorageKey);
     if (stored != null) {
-      final decoded = jsonDecode(stored) as List<dynamic>;
-      _cartItems = decoded.map((e) => e as Map<String, dynamic>?).toList();
-      notifyListeners();
+      try {
+        final decoded = jsonDecode(stored) as List<dynamic>;
+        _cartItems = decoded.map((e) => e as Map<String, dynamic>?).toList();
+        notifyListeners();
+      } catch (e) {
+        log.e("Corrupted local cart data, clearing: $e");
+        _clearLocalCart();
+      }
     }
   }
 
-  void _clearLocalCart() {
-    _sharedPreferences.remove(_cartStorageKey);
+  Future<void> _clearLocalCart() async {
+    try {
+      await _sharedPreferences.remove(_cartStorageKey);
+    } catch (e) {
+      log.e("Failed to clear local cart: $e");
+    }
   }
 
   @override

--- a/lib/features/profile/ui/viewmodels/profile_viewmodel.dart
+++ b/lib/features/profile/ui/viewmodels/profile_viewmodel.dart
@@ -6,7 +6,9 @@ import 'package:bondly_app/features/auth/domain/usecases/logout_usecase.dart';
 import 'package:bondly_app/features/auth/domain/usecases/user_usecase.dart';
 import 'package:bondly_app/features/auth/ui/screens/login_screen.dart';
 import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
+import 'package:bondly_app/features/profile/domain/models/account_statement_model.dart';
 import 'package:bondly_app/features/profile/domain/models/user_profile.dart';
+import 'package:bondly_app/features/profile/domain/usecases/get_account_statement_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/update_user_avatar_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/user_profile_use_case.dart';
 import 'package:logger/logger.dart';
@@ -17,15 +19,20 @@ class ProfileViewModel extends NavigationModel {
   final LogoutUseCase logoutUseCase;
   final UpdateUserAvatarUseCase updateUserUseCase;
   final UserProfileUseCase profileUseCase;
+  final GetAccountStatementUseCase getAccountStatementUseCase;
   User? user;
   UserProfile? userProfile;
   bool showUserUpdateError = false;
+
+  int? _spendableBalance;
+  int? get spendableBalance => _spendableBalance;
 
   ProfileViewModel(
       {required this.userUseCase,
       required this.logoutUseCase,
       required this.updateUserUseCase,
-      required this.profileUseCase});
+      required this.profileUseCase,
+      required this.getAccountStatementUseCase});
 
   Future<void> load({bool remote = true}) async {
     busy = true;
@@ -40,6 +47,19 @@ class ProfileViewModel extends NavigationModel {
       busy = false;
       notifyListeners();
       handleError(error);
+    });
+
+    fetchSpendableBalance();
+  }
+
+  Future<void> fetchSpendableBalance() async {
+    Result<AccountStatement, Exception> result =
+        await getAccountStatementUseCase.invoke();
+    result.when((statement) {
+      _spendableBalance = statement.balance;
+      notifyListeners();
+    }, (error) {
+      Logger().e("Error fetching spendable balance: $error");
     });
   }
 

--- a/lib/features/profile/ui/viewmodels/profile_viewmodel.dart
+++ b/lib/features/profile/ui/viewmodels/profile_viewmodel.dart
@@ -43,13 +43,12 @@ class ProfileViewModel extends NavigationModel {
       this.user = user;
       busy = false;
       notifyListeners();
+      fetchSpendableBalance();
     }, (error) {
       busy = false;
       notifyListeners();
       handleError(error);
     });
-
-    fetchSpendableBalance();
   }
 
   Future<void> fetchSpendableBalance() async {


### PR DESCRIPTION
 ## Summary                                                                               
                                         
  - Agrega validación de puntos disponibles antes de agregar items al carrito de           
  recompensas                                                                              
  - Muestra el balance real del usuario (desde `AccountStatement`) en el header de
  recompensas y en el perfil
  - Persiste el carrito localmente via `SharedPreferences` para que no se pierda al cerrar
  la app
  - Indica visualmente (badge rojo) cuando un item excede el balance disponible
  - Reemplaza "Puntos del mes" en perfil por "Puntos para gastar" con el valor real del
  balance
  - Renombra "Puntos recibidos" a "Puntos acumulados" para evitar confusión con el balance
  disponible
  - Extrae todos los strings hardcoded a sus clases correspondientes (`StringsCart`,
  `StringsProfile`)

  ## Cambios por archivo

  ### `lib/config/strings_cart.dart`
  - Nuevos strings: `selectItem`, `noRewardsAvailable`, `validityPrefix`, `pointsSuffix`,
  `availableBalance`, `checkoutSuccess`, `checkoutError`, `categoryAll`,
  `categoryExperiences`, `categoryGiftCards`, `categoryIncentives`

  ### `lib/config/strings_profile.dart`
  - `receivedPoints`: "Puntos recibidos" → "Puntos acumulados"
  - `monthlyPoints` → `spendablePoints`: "Puntos del mes" → "Puntos para gastar"

  ### `lib/features/profile/ui/viewmodels/my_rewards_viewmodel.dart`
  - Nuevas dependencias: `GetAccountStatementUseCase`, `SharedPreferences`
  - Nuevo estado: `userBalance`, `_rewardPointsMap`, `cartTotal`
  - Nuevos métodos: `handleGetBalance()`, `canAffordItem()`, `_saveCartToLocal()`,
  `_loadCartFromLocal()`, `_clearLocalCart()`
  - `addToCart()` ahora retorna `bool` (false = sin puntos suficientes) y acepta
  `skipValidation`
  - `init()` ahora hace `await Future.wait` e incluye `handleGetBalance()`
  - Persistencia local integrada en `addToCart`, `removeFromCart`, `handleGetUserCart`,
  `sendItemsToCart`, `handleResetAll`, `checkOutCart`

  ### `lib/features/profile/ui/viewmodels/profile_viewmodel.dart`
  - Nueva dependencia: `GetAccountStatementUseCase`
  - Nuevo estado: `spendableBalance`
  - Nuevo método: `fetchSpendableBalance()` — se llama desde `load()`

  ### `lib/features/profile/ui/screens/my_rewards_screen.dart`
  - Header: badge con "X pts disponibles" cuando el balance está disponible
  - Cards: badge de puntos en rojo cuando el usuario no puede costear el item
  - Botón "Seleccionar" y "+": muestran `SnackBar` si no hay puntos suficientes
  - Strings hardcoded reemplazados por constantes de `StringsCart` y `StringsProfile`

  ### `lib/features/profile/ui/screens/profile_screen.dart`
  - Stat card central cambiada de "Puntos del mes" (`monthlyPoints`) a "Puntos para gastar"
   (`spendableBalance`)

  ### `lib/dependencies/viewmodel_provider.dart`
  - `ProfileViewModel`: se inyecta `GetAccountStatementUseCase`
  - `MyRewardsViewModel`: se inyectan `GetAccountStatementUseCase` y `SharedPreferences`

  ## Notas técnicas

  - El balance proviene de `AccountStatement.balance` (endpoint `accountStatement/` o tabla
   `account_statements` en Supabase). Ambas implementaciones (Default y Supabase) ya
  retornan este campo — no se requirieron cambios en la capa de datos.
  - `User.pointsReceived` (perfil) ≠ `AccountStatement.balance` (balance real). El primero
  es un acumulado histórico, el segundo descuenta canjes realizados.

  ## Test plan

  - [X] Abrir perfil → verificar que "Puntos para gastar" muestra el balance correcto del
  `AccountStatement`
  - [X] Abrir perfil → verificar que "Puntos acumulados" muestra el total de puntos
  recibidos
  - [X] Abrir recompensas → verificar que el badge del header muestra "X pts disponibles"
  - [X] Agregar items al carrito hasta exceder el balance → verificar badge rojo en items
  no costeables
  - [X] Intentar agregar un item que excede el balance → verificar SnackBar "No tienes
  suficientes puntos..."
  - [ ] Cerrar y reabrir la app → verificar que el carrito local persiste
  - [ ] Completar un checkout → verificar que el carrito local se limpia
  - [X] Verificar que no hay strings hardcoded en español en los archivos modificados

|Loading|Screen|
|---|---|
|<img width="563" height="1256" alt="image" src="https://github.com/user-attachments/assets/2ff052c7-ecf4-4c65-9772-23349d1c4831" />|<img width="563" height="1256" alt="image" src="https://github.com/user-attachments/assets/186a6a65-58df-42e3-b37a-27f9d8eba611" />|
