### PR TITLE
[FEAT] Ranking UI & Embassy tab rework

### DIFF
--- a/lib/config/backend_config.dart
+++ b/lib/config/backend_config.dart
@@ -10,4 +10,5 @@ class BackendConfig {
   }
 
   static bool get isSupabase => current == BackendType.supabase;
+  static bool get isApi => current == BackendType.api;
 }

--- a/lib/config/colors.dart
+++ b/lib/config/colors.dart
@@ -99,6 +99,12 @@ class BondlyColors {
   static const Color badgeValoresStart = Color(0xFF10B981);
   static const Color badgeValoresEnd = Color(0xFF3B82F6);
 
+  // ─── Podium ───
+  static const Color lightPodiumGold = Color(0xFFF59E0B);
+  static const Color darkPodiumGold = Color(0xFFFBBF24);
+  static const Color silver = Color(0xFFC0C0C0);
+  static const Color bronze = Color(0xFFCD7F32);
+
   // ─── Fixed ───
   static const Color white = Color(0xFFFFFFFF);
 }
@@ -126,6 +132,9 @@ class BondlyColorScheme extends ThemeExtension<BondlyColorScheme> {
   final Color tabInactive;
   final Color sliderDotActive;
   final Color sliderDotInactive;
+  final Color podiumGold;
+  final Color silver;
+  final Color bronze;
 
   const BondlyColorScheme({
     required this.bg,
@@ -147,6 +156,9 @@ class BondlyColorScheme extends ThemeExtension<BondlyColorScheme> {
     required this.tabInactive,
     required this.sliderDotActive,
     required this.sliderDotInactive,
+    required this.podiumGold,
+    required this.silver,
+    required this.bronze,
   });
 
   static const light = BondlyColorScheme(
@@ -169,6 +181,9 @@ class BondlyColorScheme extends ThemeExtension<BondlyColorScheme> {
     tabInactive: BondlyColors.lightTabInactive,
     sliderDotActive: BondlyColors.lightSliderDotActive,
     sliderDotInactive: BondlyColors.lightSliderDotInactive,
+    podiumGold: BondlyColors.lightPodiumGold,
+    silver: BondlyColors.silver,
+    bronze: BondlyColors.bronze,
   );
 
   static const dark = BondlyColorScheme(
@@ -191,6 +206,9 @@ class BondlyColorScheme extends ThemeExtension<BondlyColorScheme> {
     tabInactive: BondlyColors.darkTabInactive,
     sliderDotActive: BondlyColors.darkSliderDotActive,
     sliderDotInactive: BondlyColors.darkSliderDotInactive,
+    podiumGold: BondlyColors.darkPodiumGold,
+    silver: BondlyColors.silver,
+    bronze: BondlyColors.bronze,
   );
 
   @override
@@ -214,6 +232,9 @@ class BondlyColorScheme extends ThemeExtension<BondlyColorScheme> {
     Color? tabInactive,
     Color? sliderDotActive,
     Color? sliderDotInactive,
+    Color? podiumGold,
+    Color? silver,
+    Color? bronze,
   }) {
     return BondlyColorScheme(
       bg: bg ?? this.bg,
@@ -235,6 +256,9 @@ class BondlyColorScheme extends ThemeExtension<BondlyColorScheme> {
       tabInactive: tabInactive ?? this.tabInactive,
       sliderDotActive: sliderDotActive ?? this.sliderDotActive,
       sliderDotInactive: sliderDotInactive ?? this.sliderDotInactive,
+      podiumGold: podiumGold ?? this.podiumGold,
+      silver: silver ?? this.silver,
+      bronze: bronze ?? this.bronze,
     );
   }
 
@@ -264,6 +288,9 @@ class BondlyColorScheme extends ThemeExtension<BondlyColorScheme> {
       sliderDotActive: Color.lerp(sliderDotActive, other.sliderDotActive, t)!,
       sliderDotInactive:
           Color.lerp(sliderDotInactive, other.sliderDotInactive, t)!,
+      podiumGold: Color.lerp(podiumGold, other.podiumGold, t)!,
+      silver: Color.lerp(silver, other.silver, t)!,
+      bronze: Color.lerp(bronze, other.bronze, t)!,
     );
   }
 }

--- a/lib/config/strings_home.dart
+++ b/lib/config/strings_home.dart
@@ -67,4 +67,11 @@ class StringsHome {
       'Reconocimiento enviado exitosamente';
   static const String acknowledgmentError =
       'Error al enviar reconocimiento';
+
+  // Embajadas section
+  static const String embassySectionTitle = 'Embajadas';
+  static String badgeCount(int count) => '$count insignias';
+  static const String embassyEmptyTitle = 'No hay insignias aún';
+  static const String embassyEmptyBody =
+      'Las insignias aparecerán aquí cuando estén disponibles';
 }

--- a/lib/config/strings_ranking.dart
+++ b/lib/config/strings_ranking.dart
@@ -1,0 +1,27 @@
+class StringsRanking {
+  StringsRanking._();
+
+  // Header
+  static const String title = 'Top 3 de colaboradores';
+  static const String ranking = 'Ranking';
+
+  // Period tabs
+  static const String periodMonth = 'Este mes';
+  static const String periodQuarter = 'Trimestre';
+  static const String periodYear = 'Este año';
+
+  // Count label
+  static const String countLabel = 'rec.';
+
+  // Section
+  static const String seeAll = 'Ver todo';
+
+  // Empty state
+  static const String emptyTitle = 'No hay datos de ranking';
+  static const String emptyBody =
+      'Los reconocimientos aparecerán aquí cuando haya actividad';
+
+  // Footer
+  static String footerText(int count) =>
+      'Mostrando top $count · Actualizado hoy';
+}

--- a/lib/dependencies/repository_provider.dart
+++ b/lib/dependencies/repository_provider.dart
@@ -11,6 +11,8 @@ import 'package:bondly_app/features/profile/data/repositories/supabase_account_s
 import 'package:bondly_app/features/profile/data/repositories/supabase_activity_repository.dart';
 import 'package:bondly_app/features/profile/data/repositories/supabase_bondly_badges_repository.dart';
 import 'package:bondly_app/features/profile/data/repositories/supabase_cart_repository.dart';
+import 'package:bondly_app/features/ranking/data/repositories/supabase_ranking_repository.dart';
+import 'package:bondly_app/features/ranking/domain/repositories/ranking_repository.dart';
 import 'package:bondly_app/src/supabase_client_provider.dart';
 import 'package:bondly_app/features/auth/data/repositories/api/auth_api.dart';
 import 'package:bondly_app/features/auth/data/repositories/api/users_api.dart';
@@ -154,6 +156,10 @@ class RepositoryProvider {
       DefaultSupabaseRepository(
         getIt<SupabaseClientProvider>(),
       ),
+    );
+
+    getIt.registerSingleton<RankingRepository>(
+      SupabaseRankingRepository(getIt<SupabaseClientProvider>()),
     );
   }
 }

--- a/lib/dependencies/usecase_provider.dart
+++ b/lib/dependencies/usecase_provider.dart
@@ -25,6 +25,8 @@ import 'package:bondly_app/features/profile/domain/repositories/account_statemen
 import 'package:bondly_app/features/profile/domain/repositories/activity_repository.dart';
 import 'package:bondly_app/features/profile/domain/repositories/bondly_badges_repository.dart';
 import 'package:bondly_app/features/profile/domain/repositories/cart_repository.dart';
+import 'package:bondly_app/features/ranking/domain/repositories/ranking_repository.dart';
+import 'package:bondly_app/features/ranking/domain/usecases/get_ranking_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/bulk_add_cart_items_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/checkout_cart_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/clear_shopping_cart_usecase.dart';
@@ -157,6 +159,9 @@ class UseCaseProvider {
 
     getIt.registerSingleton<GetAccountStatementUseCase>(
         GetAccountStatementUseCase(getIt<AccountStatementRepository>()));
+
+    getIt.registerSingleton<GetRankingUseCase>(
+        GetRankingUseCase(getIt<RankingRepository>()));
 
     getIt.registerSingletonWithDependencies<UserProfileUseCase>(
         () => UserProfileUseCase(

--- a/lib/dependencies/viewmodel_provider.dart
+++ b/lib/dependencies/viewmodel_provider.dart
@@ -39,6 +39,8 @@ import 'package:bondly_app/features/profile/ui/viewmodels/bondly_badges_viewmode
 import 'package:bondly_app/features/profile/ui/viewmodels/my_activity_viewmodel.dart';
 import 'package:bondly_app/features/profile/ui/viewmodels/my_rewards_viewmodel.dart';
 import 'package:bondly_app/features/profile/ui/viewmodels/profile_viewmodel.dart';
+import 'package:bondly_app/features/ranking/domain/usecases/get_ranking_usecase.dart';
+import 'package:bondly_app/features/ranking/ui/viewmodels/ranking_viewmodel.dart';
 import 'package:bondly_app/src/app_services.dart';
 import 'package:bondly_app/src/routes.dart';
 
@@ -73,6 +75,7 @@ class ViewModelProvider {
               getIt<CreateAcknowledgmentUseCase>(),
               getIt<GetCompanyAnnouncementsUseCase>(),
               getIt<GetUserEmbassysUseCase>(),
+              getIt<GetRankingUseCase>(),
             ),
         dependsOn: [UserUseCase]);
 
@@ -117,5 +120,8 @@ class ViewModelProvider {
         ));
     getIt.registerFactory<AccountStatementViewModel>(
         () => AccountStatementViewModel(getIt<GetAccountStatementUseCase>()));
+
+    getIt.registerFactory<RankingViewModel>(
+        () => RankingViewModel(getIt<GetRankingUseCase>()));
   }
 }

--- a/lib/features/home/ui/screens/ambassadors_tab.dart
+++ b/lib/features/home/ui/screens/ambassadors_tab.dart
@@ -1,4 +1,3 @@
-import 'package:bondly_app/config/backend_config.dart';
 import 'package:bondly_app/config/colors.dart';
 import 'package:bondly_app/config/dimensions.dart';
 import 'package:bondly_app/config/strings_home.dart';
@@ -74,11 +73,11 @@ class _AmbassadorsTabState extends State<AmbassadorsTab> {
             ),
             const SizedBox(height: 16),
             // Ranking section skeleton (only when ranking is enabled)
-            if (!BackendConfig.isApi) ...[
-              Row(
+            if (model.isRankingEnabled) ...[
+              const Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  const BondlyShimmerBlock(width: 100, height: 20),
+                  BondlyShimmerBlock(width: 100, height: 20),
                   BondlyShimmerBlock(width: 60, height: 14),
                 ],
               ),
@@ -91,10 +90,10 @@ class _AmbassadorsTabState extends State<AmbassadorsTab> {
               const SizedBox(height: 16),
             ],
             // Section header placeholder
-            Row(
+            const Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                const BondlyShimmerBlock(width: 120, height: 20),
+                BondlyShimmerBlock(width: 120, height: 20),
                 BondlyShimmerBlock(
                   width: 80,
                   height: 24,
@@ -191,7 +190,9 @@ class _AmbassadorsTabState extends State<AmbassadorsTab> {
   Widget _buildRankingSection(BondlyColorScheme colors) {
     final ranking = model.rankingUsers;
 
-    if (ranking.length < 3) {
+    final hasValidPodium = ranking.length >= 3 &&
+        ranking.take(3).every((u) => u.name.trim().isNotEmpty);
+    if (!hasValidPodium) {
       return const SizedBox.shrink();
     }
 
@@ -326,30 +327,20 @@ class _AmbassadorsTabState extends State<AmbassadorsTab> {
   // ─── Badge Grid (2 columns) ───────────────────────────────────────────
 
   Widget _buildBadgeGrid(List<Embassy> embassies) {
-    final rows = <Widget>[];
-    for (var i = 0; i < embassies.length; i += 2) {
-      final left = embassies[i];
-      final hasRight = i + 1 < embassies.length;
-
-      rows.add(
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(child: _buildBadgeCardFromEmbassy(left)),
-            const SizedBox(width: 12),
-            hasRight
-                ? Expanded(child: _buildBadgeCardFromEmbassy(embassies[i + 1]))
-                : const Expanded(child: SizedBox.shrink()),
-          ],
-        ),
-      );
-
-      if (i + 2 < embassies.length) {
-        rows.add(const SizedBox(height: 12));
-      }
-    }
-
-    return Column(children: rows);
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 12,
+        mainAxisSpacing: 12,
+        childAspectRatio: 0.85,
+      ),
+      itemCount: embassies.length,
+      itemBuilder: (context, index) {
+        return _buildBadgeCardFromEmbassy(embassies[index]);
+      },
+    );
   }
 
   Widget _buildBadgeCardFromEmbassy(Embassy embassy) {
@@ -366,24 +357,30 @@ class _AmbassadorsTabState extends State<AmbassadorsTab> {
       icon: icon,
       imageUrl: badge?.image,
       onTap: () {
-        // TODO: Navigate to badge detail
+        // TODO(BONDLY): Navigate to badge detail screen
       },
     );
   }
 
   // ─── Category Helpers ─────────────────────────────────────────────────
 
+  Map<String, Category>? _categoryLookup;
+
+  Map<String, Category> _getCategoryLookup() {
+    if (_categoryLookup != null) return _categoryLookup!;
+    final categories = model.categories.categories ?? [];
+    _categoryLookup = {
+      for (final cat in categories)
+        if (cat.id != null) cat.id!: cat,
+    };
+    return _categoryLookup!;
+  }
+
   BadgeType _resolveBadgeType(Badge? badge) {
     if (badge?.categoryId == null) return BadgeType.competencias;
 
-    final categories = model.categories.categories ?? [];
-    Category? matchedCategory;
-    for (final cat in categories) {
-      if (cat.id == badge!.categoryId) {
-        matchedCategory = cat;
-        break;
-      }
-    }
+    final lookup = _getCategoryLookup();
+    final matchedCategory = lookup[badge!.categoryId];
 
     if (matchedCategory != null) {
       final name =

--- a/lib/features/home/ui/screens/ambassadors_tab.dart
+++ b/lib/features/home/ui/screens/ambassadors_tab.dart
@@ -1,7 +1,22 @@
-import 'package:bondly_app/src/network_image_helpers.dart';
+import 'package:bondly_app/config/backend_config.dart';
+import 'package:bondly_app/config/colors.dart';
+import 'package:bondly_app/config/dimensions.dart';
+import 'package:bondly_app/config/strings_home.dart';
+import 'package:bondly_app/config/strings_ranking.dart';
+import 'package:bondly_app/features/home/domain/models/badge_model.dart';
+import 'package:bondly_app/features/home/domain/models/company_categories.dart';
+import 'package:bondly_app/features/home/domain/models/embassys_model.dart';
 import 'package:bondly_app/features/home/ui/viewmodels/home_viewmodel.dart';
-import 'package:bondly_app/features/home/ui/widgets/gold_bordered_container.dart';
-import 'package:flutter/material.dart';
+import 'package:bondly_app/features/ranking/ui/screens/ranking_screen.dart';
+import 'package:bondly_app/ui/shared/badge_card.dart';
+import 'package:bondly_app/ui/shared/badge_icon_button.dart' show BadgeType;
+import 'package:bondly_app/ui/shared/bondly_skeleton.dart';
+import 'package:bondly_app/ui/shared/podium_widget.dart';
+import 'package:bondly_app/ui/shared/slider_banner_card.dart';
+import 'package:flutter/material.dart' hide Badge;
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:lucide_icons/lucide_icons.dart';
 
 class AmbassadorsTab extends StatefulWidget {
   final HomeViewModel model;
@@ -12,60 +27,415 @@ class AmbassadorsTab extends StatefulWidget {
 }
 
 class _AmbassadorsTabState extends State<AmbassadorsTab> {
-  late HomeViewModel model;
-  @override
-  void initState() {
-    model = widget.model;
-    super.initState();
-  }
+  HomeViewModel get model => widget.model;
+
+  bool get _isLoading => model.user == null;
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: SizedBox(
-        height: MediaQuery.of(context).size.height * 0.45,
-        child: GoldBorderedContainer(
-          child: Column(
+    final colors = Theme.of(context).extension<BondlyColorScheme>()!;
+
+    if (_isLoading) return _buildSkeletonState(colors);
+
+    final showRanking = model.isRankingEnabled;
+
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          _buildSliderSection(),
+          const SizedBox(height: 16),
+          if (showRanking) ...[
+            _buildRankingSection(colors),
+            const SizedBox(height: 16),
+          ],
+          _buildBadgesSection(colors),
+          const SizedBox(height: 20),
+        ],
+      ),
+    );
+  }
+
+  // ─── Skeleton Loading State ───────────────────────────────────────────
+
+  Widget _buildSkeletonState(BondlyColorScheme colors) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.paddingScreen,
+        ),
+        child: Column(
+          children: [
+            const SizedBox(height: 8),
+            // Slider placeholder
+            const BondlyShimmerBlock(
+              width: double.infinity,
+              height: 180,
+              borderRadius: 20,
+            ),
+            const SizedBox(height: 16),
+            // Ranking section skeleton (only when ranking is enabled)
+            if (!BackendConfig.isApi) ...[
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const BondlyShimmerBlock(width: 100, height: 20),
+                  BondlyShimmerBlock(width: 60, height: 14),
+                ],
+              ),
+              const SizedBox(height: 12),
+              const BondlyShimmerBlock(
+                width: double.infinity,
+                height: 220,
+                borderRadius: 8,
+              ),
+              const SizedBox(height: 16),
+            ],
+            // Section header placeholder
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const BondlyShimmerBlock(width: 120, height: 20),
+                BondlyShimmerBlock(
+                  width: 80,
+                  height: 24,
+                  borderRadius: 10,
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            // Grid placeholder (2x3)
+            for (var i = 0; i < 3; i++) ...[
+              Row(
+                children: [
+                  Expanded(child: _buildBadgeCardSkeleton(colors)),
+                  const SizedBox(width: 12),
+                  Expanded(child: _buildBadgeCardSkeleton(colors)),
+                ],
+              ),
+              if (i < 2) const SizedBox(height: 12),
+            ],
+            const SizedBox(height: 20),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBadgeCardSkeleton(BondlyColorScheme colors) {
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: colors.border, width: 1),
+      ),
+      child: const Column(
+        children: [
+          SizedBox(height: 80, child: Center(child: BondlyShimmerCircle(size: 52))),
+          Padding(
+            padding: EdgeInsets.all(12),
+            child: Column(
+              children: [
+                BondlyShimmerBlock(width: 80, height: 13),
+                SizedBox(height: 6),
+                BondlyShimmerBlock(width: 60, height: 10),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ─── Slider Section ───────────────────────────────────────────────────
+
+  Widget _buildSliderSection() {
+    return const Padding(
+      padding: EdgeInsets.fromLTRB(
+        AppDimensions.paddingScreen,
+        8,
+        AppDimensions.paddingScreen,
+        0,
+      ),
+      child: SliderBannerCard(
+        items: [
+          BannerItem(
+            tag: StringsHome.bannerTag1,
+            title: StringsHome.bannerTitle1,
+            subtitle: StringsHome.bannerSubtitle1,
+          ),
+          BannerItem(
+            tag: StringsHome.bannerTag2,
+            title: StringsHome.bannerTitle2,
+            subtitle: StringsHome.bannerSubtitle2,
+          ),
+          BannerItem(
+            title: StringsHome.bannerTitle3,
+            subtitle: StringsHome.bannerSubtitle3,
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ─── Ranking Section ─────────────────────────────────────────────────
+
+  PodiumEntry _toPodiumEntry(dynamic user) {
+    return PodiumEntry(
+      name: user.name,
+      avatarUrl: user.avatarUrl,
+      count: user.recognitionCount,
+      countLabel: StringsRanking.countLabel,
+    );
+  }
+
+  Widget _buildRankingSection(BondlyColorScheme colors) {
+    final ranking = model.rankingUsers;
+
+    if (ranking.length < 3) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      children: [
+        // Section header
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppDimensions.paddingScreen,
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                "Embajadas",
-                style: Theme.of(context).textTheme.titleLarge,
+                StringsRanking.title,
+                style: GoogleFonts.montserrat(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  color: colors.textPrimary,
+                ),
               ),
-              Expanded(
-                child: GridView.builder(
-                    gridDelegate:
-                        const SliverGridDelegateWithFixedCrossAxisCount(
-                            crossAxisCount: 2),
-                    itemCount: model.embassys.length,
-                    itemBuilder: (ctx, index) {
-                      return AspectRatio(
-                        aspectRatio: 1,
-                        child: Column(
-                          children: [
-                            Expanded(
-                              child: Container(
-                                decoration: BoxDecoration(
-                                  image: DecorationImage(
-                                    image: NetworkImage(safeImageUrl(
-                                        model.embassys[index].badgeId?.image)),
-                                  ),
-                                ),
-                              ),
-                            ),
-                            Text(
-                              model.embassys[index].badgeId!.name!,
-                              style: Theme.of(context).textTheme.titleMedium,
-                            ),
-                          ],
-                        ),
-                      );
-                    }),
+              GestureDetector(
+                onTap: () => context.push(RankingScreen.route),
+                child: Text(
+                  StringsRanking.seeAll,
+                  style: GoogleFonts.montserrat(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: colors.accent,
+                  ),
+                ),
               ),
             ],
           ),
         ),
+        const SizedBox(height: 4),
+        // Podium widget
+        PodiumWidget(
+          first: _toPodiumEntry(ranking[0]),
+          second: _toPodiumEntry(ranking[1]),
+          third: _toPodiumEntry(ranking[2]),
+        ),
+      ],
+    );
+  }
+
+  // ─── Badges Section ───────────────────────────────────────────────────
+
+  Widget _buildBadgesSection(BondlyColorScheme colors) {
+    final embassies = model.embassys;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.paddingScreen,
+      ),
+      child: Column(
+        children: [
+          // Section header
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                StringsHome.embassySectionTitle,
+                style: GoogleFonts.montserrat(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  color: colors.textPrimary,
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 4,
+                ),
+                decoration: BoxDecoration(
+                  color: colors.accentSoft,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  StringsHome.badgeCount(embassies.length),
+                  style: GoogleFonts.montserrat(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: colors.accent,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          // Grid or empty state
+          embassies.isEmpty
+              ? _buildEmptyState(colors)
+              : _buildBadgeGrid(embassies),
+        ],
       ),
     );
+  }
+
+  Widget _buildEmptyState(BondlyColorScheme colors) {
+    return SizedBox(
+      height: 200,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(LucideIcons.trophy, size: 48, color: colors.textMuted),
+            const SizedBox(height: 16),
+            Text(
+              StringsHome.embassyEmptyTitle,
+              style: GoogleFonts.montserrat(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: colors.textSecondary,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              StringsHome.embassyEmptyBody,
+              textAlign: TextAlign.center,
+              style: GoogleFonts.montserrat(
+                fontSize: 13,
+                color: colors.textMuted,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ─── Badge Grid (2 columns) ───────────────────────────────────────────
+
+  Widget _buildBadgeGrid(List<Embassy> embassies) {
+    final rows = <Widget>[];
+    for (var i = 0; i < embassies.length; i += 2) {
+      final left = embassies[i];
+      final hasRight = i + 1 < embassies.length;
+
+      rows.add(
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(child: _buildBadgeCardFromEmbassy(left)),
+            const SizedBox(width: 12),
+            hasRight
+                ? Expanded(child: _buildBadgeCardFromEmbassy(embassies[i + 1]))
+                : const Expanded(child: SizedBox.shrink()),
+          ],
+        ),
+      );
+
+      if (i + 2 < embassies.length) {
+        rows.add(const SizedBox(height: 12));
+      }
+    }
+
+    return Column(children: rows);
+  }
+
+  Widget _buildBadgeCardFromEmbassy(Embassy embassy) {
+    final badge = embassy.badgeId;
+    final badgeType = _resolveBadgeType(badge);
+    final gradientColors = _gradientColorsForType(badgeType);
+    final icon = _iconForType(badgeType);
+    final categoryLabel = _categoryLabelForType(badgeType);
+
+    return BadgeCard(
+      name: badge?.name ?? '',
+      categoryLabel: categoryLabel,
+      gradientColors: gradientColors,
+      icon: icon,
+      imageUrl: badge?.image,
+      onTap: () {
+        // TODO: Navigate to badge detail
+      },
+    );
+  }
+
+  // ─── Category Helpers ─────────────────────────────────────────────────
+
+  BadgeType _resolveBadgeType(Badge? badge) {
+    if (badge?.categoryId == null) return BadgeType.competencias;
+
+    final categories = model.categories.categories ?? [];
+    Category? matchedCategory;
+    for (final cat in categories) {
+      if (cat.id == badge!.categoryId) {
+        matchedCategory = cat;
+        break;
+      }
+    }
+
+    if (matchedCategory != null) {
+      final name =
+          (matchedCategory.name ?? matchedCategory.type ?? '').toLowerCase();
+      if (name.contains('especial')) return BadgeType.especiales;
+      if (name.contains('valor') || name.contains('embajada')) {
+        return BadgeType.valores;
+      }
+    }
+
+    return BadgeType.competencias;
+  }
+
+  static List<Color> _gradientColorsForType(BadgeType type) {
+    switch (type) {
+      case BadgeType.competencias:
+        return const [
+          BondlyColors.badgeCompetenciasStart,
+          BondlyColors.badgeCompetenciasEnd,
+        ];
+      case BadgeType.especiales:
+        return const [
+          BondlyColors.badgeEspecialesStart,
+          BondlyColors.badgeEspecialesEnd,
+        ];
+      case BadgeType.valores:
+        return const [
+          BondlyColors.badgeValoresStart,
+          BondlyColors.badgeValoresEnd,
+        ];
+    }
+  }
+
+  static IconData _iconForType(BadgeType type) {
+    switch (type) {
+      case BadgeType.competencias:
+        return LucideIcons.award;
+      case BadgeType.especiales:
+        return LucideIcons.star;
+      case BadgeType.valores:
+        return LucideIcons.heart;
+    }
+  }
+
+  static String _categoryLabelForType(BadgeType type) {
+    switch (type) {
+      case BadgeType.competencias:
+        return StringsHome.badgeCompetencias;
+      case BadgeType.especiales:
+        return StringsHome.badgeEspeciales;
+      case BadgeType.valores:
+        return StringsHome.badgeValores;
+    }
   }
 }

--- a/lib/features/home/ui/viewmodels/home_viewmodel.dart
+++ b/lib/features/home/ui/viewmodels/home_viewmodel.dart
@@ -20,6 +20,9 @@ import 'package:bondly_app/features/home/domain/usecases/get_company_collaborato
 import 'package:bondly_app/features/home/domain/usecases/get_company_feeds.dart';
 import 'package:bondly_app/features/home/domain/usecases/get_user_embassys.dart';
 import 'package:bondly_app/features/home/domain/usecases/handle_like.dart';
+import 'package:bondly_app/config/backend_config.dart';
+import 'package:bondly_app/features/ranking/domain/models/ranked_user.dart';
+import 'package:bondly_app/features/ranking/domain/usecases/get_ranking_usecase.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_mentions/flutter_mentions.dart';
@@ -44,6 +47,7 @@ class HomeViewModel extends NavigationModel {
   final CreateAcknowledgmentUseCase _createAcknowledgmentUseCase;
   final GetCompanyAnnouncementsUseCase _getCompanyAnnouncementsUseCase;
   final GetUserEmbassysUseCase _getUserEmbassysUseCase;
+  final GetRankingUseCase _getRankingUseCase;
 
   final GlobalKey<FlutterMentionsState> mentionsKey =
       GlobalKey<FlutterMentionsState>();
@@ -65,7 +69,8 @@ class HomeViewModel extends NavigationModel {
       this._getCompanyCollaboratorsUseCase,
       this._createAcknowledgmentUseCase,
       this._getCompanyAnnouncementsUseCase,
-      this._getUserEmbassysUseCase) {
+      this._getUserEmbassysUseCase,
+      this._getRankingUseCase) {
     log.i("HomeViewModel created");
   }
 
@@ -97,6 +102,7 @@ class HomeViewModel extends NavigationModel {
       getCompanyCategories(),
       getCompanyCollaborators(),
       handleGetAnnounceMents(),
+      getRanking(),
     ]);
   }
 
@@ -446,6 +452,30 @@ class HomeViewModel extends NavigationModel {
       if (error is TokenNotFoundException) {
         // Dispatch logout
       }
+    });
+  }
+
+  // ─── Ranking ──────────────────────────────────────────────────────────
+
+  bool get isRankingEnabled => !BackendConfig.isApi;
+
+  List<RankedUser> _rankingUsers = [];
+  List<RankedUser> get rankingUsers => _rankingUsers;
+  set rankingUsers(List<RankedUser> data) {
+    _rankingUsers = data;
+    notifyListeners();
+  }
+
+  Future<void> getRanking() async {
+    if (!isRankingEnabled) return;
+
+    log.i("Get Ranking for home podium");
+    final result = await _getRankingUseCase.invoke(period: 'month', limit: 3);
+    result.when((users) {
+      log.i("HomeViewModel### Ranking: ${users.length} users");
+      rankingUsers = users;
+    }, (error) {
+      log.e("HomeViewModel### Ranking Error: $error");
     });
   }
 }

--- a/lib/features/ranking/data/repositories/supabase_ranking_repository.dart
+++ b/lib/features/ranking/data/repositories/supabase_ranking_repository.dart
@@ -1,0 +1,31 @@
+import 'package:bondly_app/features/ranking/domain/models/ranked_user.dart';
+import 'package:bondly_app/features/ranking/domain/repositories/ranking_repository.dart';
+import 'package:bondly_app/src/supabase_client_provider.dart';
+import 'package:multiple_result/multiple_result.dart';
+
+class SupabaseRankingRepository extends RankingRepository {
+  final SupabaseClientProvider _provider;
+
+  SupabaseRankingRepository(this._provider);
+
+  @override
+  Future<Result<List<RankedUser>, Exception>> getRanking({
+    String period = 'month',
+    int limit = 10,
+  }) async {
+    try {
+      final response = await _provider.client.rpc('get_ranking', params: {
+        'period_filter': period,
+        'result_limit': limit,
+      });
+
+      final users = (response as List)
+          .map((row) => RankedUser.fromSupabase(row as Map<String, dynamic>))
+          .toList();
+
+      return Result.success(users);
+    } catch (exception) {
+      return Result.error(RankingFetchException(exception.toString()));
+    }
+  }
+}

--- a/lib/features/ranking/domain/models/ranked_user.dart
+++ b/lib/features/ranking/domain/models/ranked_user.dart
@@ -1,0 +1,25 @@
+class RankedUser {
+  final int position;
+  final String name;
+  final String? avatarUrl;
+  final String? department;
+  final int recognitionCount;
+
+  const RankedUser({
+    required this.position,
+    required this.name,
+    this.avatarUrl,
+    this.department,
+    required this.recognitionCount,
+  });
+
+  factory RankedUser.fromSupabase(Map<String, dynamic> json) {
+    return RankedUser(
+      position: (json['position'] as num).toInt(),
+      name: json['complete_name'] as String? ?? '',
+      avatarUrl: json['avatar'] as String?,
+      department: json['job_position'] as String?,
+      recognitionCount: (json['recognition_count'] as num).toInt(),
+    );
+  }
+}

--- a/lib/features/ranking/domain/repositories/ranking_repository.dart
+++ b/lib/features/ranking/domain/repositories/ranking_repository.dart
@@ -1,0 +1,20 @@
+import 'package:bondly_app/features/ranking/domain/models/ranked_user.dart';
+import 'package:multiple_result/multiple_result.dart';
+
+abstract class RankingRepository {
+  /// Retrieves the ranking of users filtered by [period].
+  /// Valid periods: 'month', 'quarter', 'year'.
+  /// [limit] controls how many users are returned (default 10).
+  Future<Result<List<RankedUser>, Exception>> getRanking({
+    String period = 'month',
+    int limit = 10,
+  });
+}
+
+class RankingFetchException implements Exception {
+  final String message;
+  RankingFetchException([this.message = 'Error fetching ranking']);
+
+  @override
+  String toString() => message;
+}

--- a/lib/features/ranking/domain/usecases/get_ranking_usecase.dart
+++ b/lib/features/ranking/domain/usecases/get_ranking_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:bondly_app/features/ranking/domain/models/ranked_user.dart';
+import 'package:bondly_app/features/ranking/domain/repositories/ranking_repository.dart';
+import 'package:multiple_result/multiple_result.dart';
+
+class GetRankingUseCase {
+  final RankingRepository repository;
+
+  GetRankingUseCase(this.repository);
+
+  Future<Result<List<RankedUser>, Exception>> invoke({
+    String period = 'month',
+    int limit = 10,
+  }) async {
+    return await repository.getRanking(period: period, limit: limit);
+  }
+}

--- a/lib/features/ranking/ui/screens/ranking_screen.dart
+++ b/lib/features/ranking/ui/screens/ranking_screen.dart
@@ -63,7 +63,8 @@ class _RankingScreenState extends State<RankingScreen> {
             Expanded(
               child: model.loading
                   ? const Center(child: CircularProgressIndicator())
-                  : topThree.length < 3
+                  : topThree.length < 3 ||
+                          topThree.any((u) => u.name.trim().isEmpty)
                       ? _buildEmptyState(colors)
                       : SingleChildScrollView(
                           child: Column(
@@ -339,6 +340,11 @@ class _RankingScreenState extends State<RankingScreen> {
                 width: 40,
                 height: 40,
                 fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => Icon(
+                  LucideIcons.user,
+                  size: 20,
+                  color: colors.textMuted,
+                ),
               ),
             )
           : Icon(

--- a/lib/features/ranking/ui/screens/ranking_screen.dart
+++ b/lib/features/ranking/ui/screens/ranking_screen.dart
@@ -1,0 +1,376 @@
+import 'package:bondly_app/config/colors.dart';
+import 'package:bondly_app/config/dimensions.dart';
+import 'package:bondly_app/config/strings_ranking.dart';
+import 'package:bondly_app/dependencies/dependency_manager.dart';
+import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
+import 'package:bondly_app/features/ranking/domain/models/ranked_user.dart';
+import 'package:bondly_app/features/ranking/ui/viewmodels/ranking_viewmodel.dart';
+import 'package:bondly_app/ui/shared/podium_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+
+class RankingScreen extends StatefulWidget {
+  static const String route = '/rankingScreen';
+
+  const RankingScreen({super.key});
+
+  @override
+  State<RankingScreen> createState() => _RankingScreenState();
+}
+
+class _RankingScreenState extends State<RankingScreen> {
+  late final RankingViewModel _viewModel;
+
+  final List<String> _periods = [
+    StringsRanking.periodMonth,
+    StringsRanking.periodQuarter,
+    StringsRanking.periodYear,
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _viewModel = getIt<RankingViewModel>();
+    _viewModel.setUp();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ModelProvider<RankingViewModel>(
+      model: _viewModel,
+      child: ModelBuilder<RankingViewModel>(
+        builder: (context, model, child) {
+          final colors = Theme.of(context).extension<BondlyColorScheme>()!;
+          return _buildScreen(colors, model);
+        },
+      ),
+    );
+  }
+
+  Widget _buildScreen(BondlyColorScheme colors, RankingViewModel model) {
+    final topThree = model.topThree;
+    final rest = model.rest;
+
+    return Scaffold(
+      backgroundColor: colors.bg,
+      body: SafeArea(
+        child: Column(
+          children: [
+            _buildHeader(colors),
+            _buildPeriodTabs(colors, model),
+            Expanded(
+              child: model.loading
+                  ? const Center(child: CircularProgressIndicator())
+                  : topThree.length < 3
+                      ? _buildEmptyState(colors)
+                      : SingleChildScrollView(
+                          child: Column(
+                            children: [
+                              const SizedBox(height: 16),
+                              PodiumWidget(
+                                first: _toPodiumEntry(topThree[0]),
+                                second: _toPodiumEntry(topThree[1]),
+                                third: _toPodiumEntry(topThree[2]),
+                              ),
+                              const SizedBox(height: 16),
+                              _buildRankingList(colors, rest),
+                              _buildFooter(colors, model.users.length),
+                            ],
+                          ),
+                        ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  PodiumEntry _toPodiumEntry(RankedUser user) {
+    return PodiumEntry(
+      name: user.name,
+      avatarUrl: user.avatarUrl,
+      count: user.recognitionCount,
+      countLabel: StringsRanking.countLabel,
+    );
+  }
+
+  // ─── Header ──────────────────────────────────────────────────────────
+
+  Widget _buildHeader(BondlyColorScheme colors) {
+    return SizedBox(
+      height: 56,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.paddingScreen,
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            GestureDetector(
+              onTap: () => context.pop(),
+              child: Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: colors.surfaceElevated,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  LucideIcons.arrowLeft,
+                  size: 18,
+                  color: colors.textPrimary,
+                ),
+              ),
+            ),
+            Text(
+              StringsRanking.ranking,
+              style: GoogleFonts.montserrat(
+                fontSize: 18,
+                fontWeight: FontWeight.w700,
+                color: colors.textPrimary,
+              ),
+            ),
+            const SizedBox(width: 36),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ─── Period Tabs ─────────────────────────────────────────────────────
+
+  Widget _buildPeriodTabs(BondlyColorScheme colors, RankingViewModel model) {
+    return SizedBox(
+      height: 44,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.paddingScreen,
+        ),
+        child: Row(
+          children: List.generate(_periods.length, (index) {
+            final isActive = model.selectedPeriod == index;
+            return Padding(
+              padding: EdgeInsets.only(
+                right: index < _periods.length - 1
+                    ? AppDimensions.spacingSm
+                    : 0,
+              ),
+              child: GestureDetector(
+                onTap: () => model.selectedPeriod = index,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  height: 34,
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(17),
+                    gradient: isActive
+                        ? AppDimensions.accentGradient(colors)
+                        : null,
+                    color: isActive ? null : colors.surface,
+                    border: isActive
+                        ? null
+                        : Border.all(color: colors.border, width: 1.5),
+                  ),
+                  child: Center(
+                    child: Text(
+                      _periods[index],
+                      style: GoogleFonts.montserrat(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: isActive
+                            ? BondlyColors.white
+                            : colors.textSecondary,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+          }),
+        ),
+      ),
+    );
+  }
+
+  // ─── Empty State ─────────────────────────────────────────────────────
+
+  Widget _buildEmptyState(BondlyColorScheme colors) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(LucideIcons.trophy, size: 48, color: colors.textMuted),
+          const SizedBox(height: 16),
+          Text(
+            StringsRanking.emptyTitle,
+            style: GoogleFonts.montserrat(
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+              color: colors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            StringsRanking.emptyBody,
+            textAlign: TextAlign.center,
+            style: GoogleFonts.montserrat(
+              fontSize: 13,
+              color: colors.textMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ─── Ranking List ────────────────────────────────────────────────────
+
+  Widget _buildRankingList(BondlyColorScheme colors, List<RankedUser> users) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.paddingScreen,
+      ),
+      child: Column(
+        children: List.generate(users.length, (index) {
+          final user = users[index];
+          final isLast = index == users.length - 1;
+
+          return Container(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            decoration: isLast
+                ? null
+                : BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(color: colors.border, width: 1),
+                    ),
+                  ),
+            child: Row(
+              children: [
+                // Position number
+                SizedBox(
+                  width: 24,
+                  child: Text(
+                    '${user.position}',
+                    textAlign: TextAlign.center,
+                    style: GoogleFonts.montserrat(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      color: colors.textMuted,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                // Avatar
+                _buildListAvatar(colors, user),
+                const SizedBox(width: 12),
+                // Name & department
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        user.name,
+                        style: GoogleFonts.montserrat(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                          color: colors.textPrimary,
+                        ),
+                      ),
+                      if (user.department != null) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          user.department!,
+                          style: GoogleFonts.montserrat(
+                            fontSize: 11,
+                            color: colors.textMuted,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                // Recognition count
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      '${user.recognitionCount}',
+                      style: GoogleFonts.montserrat(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                        color: colors.accent,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      StringsRanking.countLabel,
+                      style: GoogleFonts.montserrat(
+                        fontSize: 10,
+                        color: colors.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          );
+        }),
+      ),
+    );
+  }
+
+  Widget _buildListAvatar(BondlyColorScheme colors, RankedUser user) {
+    final hasAvatar = user.avatarUrl != null && user.avatarUrl!.isNotEmpty;
+
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: colors.surfaceElevated,
+        border: Border.all(color: colors.border, width: 1),
+      ),
+      child: hasAvatar
+          ? ClipOval(
+              child: Image.network(
+                user.avatarUrl!,
+                width: 40,
+                height: 40,
+                fit: BoxFit.cover,
+              ),
+            )
+          : Icon(
+              LucideIcons.user,
+              size: 20,
+              color: colors.textMuted,
+            ),
+    );
+  }
+
+  // ─── Footer ──────────────────────────────────────────────────────────
+
+  Widget _buildFooter(BondlyColorScheme colors, int count) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        vertical: AppDimensions.spacingLg,
+        horizontal: AppDimensions.paddingScreen,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(LucideIcons.info, size: 14, color: colors.textMuted),
+          const SizedBox(width: 6),
+          Text(
+            StringsRanking.footerText(count),
+            style: GoogleFonts.montserrat(
+              fontSize: 11,
+              color: colors.textMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/ranking/ui/viewmodels/ranking_viewmodel.dart
+++ b/lib/features/ranking/ui/viewmodels/ranking_viewmodel.dart
@@ -1,0 +1,61 @@
+import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
+import 'package:bondly_app/features/ranking/domain/models/ranked_user.dart';
+import 'package:bondly_app/features/ranking/domain/usecases/get_ranking_usecase.dart';
+import 'package:logger/logger.dart';
+
+class RankingViewModel extends NavigationModel {
+  final GetRankingUseCase _getRankingUseCase;
+
+  final Logger log = Logger(printer: PrettyPrinter(methodCount: 0));
+
+  RankingViewModel(this._getRankingUseCase);
+
+  static const List<String> periodKeys = ['month', 'quarter', 'year'];
+
+  int _selectedPeriod = 0;
+  int get selectedPeriod => _selectedPeriod;
+  set selectedPeriod(int index) {
+    _selectedPeriod = index;
+    notifyListeners();
+    fetchRanking();
+  }
+
+  bool _loading = false;
+  bool get loading => _loading;
+
+  List<RankedUser> _users = [];
+  List<RankedUser> get users => _users;
+
+  List<RankedUser> get topThree =>
+      _users.length >= 3 ? _users.sublist(0, 3) : _users;
+
+  List<RankedUser> get rest => _users.length > 3 ? _users.sublist(3) : [];
+
+  Future<void> setUp() async {
+    await fetchRanking();
+  }
+
+  Future<void> fetchRanking() async {
+    _loading = true;
+    notifyListeners();
+
+    final result = await _getRankingUseCase.invoke(
+      period: periodKeys[_selectedPeriod],
+      limit: 10,
+    );
+
+    result.when(
+      (users) {
+        log.i('RankingViewModel### Ranking fetched: ${users.length} users');
+        _users = users;
+      },
+      (error) {
+        log.e('RankingViewModel### Error: $error');
+        _users = [];
+      },
+    );
+
+    _loading = false;
+    notifyListeners();
+  }
+}

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -10,6 +10,7 @@ import 'package:bondly_app/features/profile/ui/screens/my_data_screen.dart';
 import 'package:bondly_app/features/profile/ui/screens/my_rewards_screen.dart';
 import 'package:bondly_app/features/profile/ui/screens/profile_screen.dart';
 import 'package:bondly_app/features/profile/ui/screens/shopping_cart_screen.dart';
+import 'package:bondly_app/features/ranking/ui/screens/ranking_screen.dart';
 import 'package:bondly_app/features/start/ui/screens/start_screen.dart';
 import 'package:go_router/go_router.dart';
 
@@ -55,6 +56,9 @@ class AppRouter {
       GoRoute(
           path: MyBadgesScreen.route,
           builder: (context, state) => const MyBadgesScreen()),
+      GoRoute(
+          path: RankingScreen.route,
+          builder: (context, state) => const RankingScreen()),
       GoRoute(
           path: MyDataScreen.route,
           builder: (context, state) => const MyDataScreen()),

--- a/lib/ui/shared/badge_card.dart
+++ b/lib/ui/shared/badge_card.dart
@@ -1,0 +1,121 @@
+import 'package:bondly_app/config/colors.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class BadgeCard extends StatelessWidget {
+  final String name;
+  final String categoryLabel;
+  final List<Color> gradientColors;
+  final IconData icon;
+  final String? imageUrl;
+  final VoidCallback? onTap;
+
+  const BadgeCard({
+    super.key,
+    required this.name,
+    required this.categoryLabel,
+    required this.gradientColors,
+    required this.icon,
+    this.imageUrl,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<BondlyColorScheme>()!;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        clipBehavior: Clip.antiAlias,
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: colors.border, width: 1),
+        ),
+        child: Column(
+          children: [
+            // Top area — soft gradient background + icon circle
+            Container(
+              height: 80,
+              width: double.infinity,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topRight,
+                  end: Alignment.bottomLeft,
+                  colors: [
+                    gradientColors[0].withValues(alpha: 0.094),
+                    gradientColors[1].withValues(alpha: 0.094),
+                  ],
+                ),
+              ),
+              child: Center(
+                child: Container(
+                  width: 52,
+                  height: 52,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    gradient: LinearGradient(
+                      begin: Alignment.topRight,
+                      end: Alignment.bottomLeft,
+                      colors: gradientColors,
+                    ),
+                  ),
+                  child: _buildIconContent(colors),
+                ),
+              ),
+            ),
+            // Info area
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                children: [
+                  Text(
+                    name,
+                    textAlign: TextAlign.center,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: GoogleFonts.montserrat(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: colors.textPrimary,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    categoryLabel,
+                    style: GoogleFonts.montserrat(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w500,
+                      color: colors.textMuted,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIconContent(BondlyColorScheme colors) {
+    if (imageUrl != null && imageUrl!.isNotEmpty) {
+      return ClipOval(
+        child: Image.network(
+          imageUrl!,
+          width: 52,
+          height: 52,
+          fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) => Icon(
+            icon,
+            size: 24,
+            color: BondlyColors.white,
+          ),
+        ),
+      );
+    }
+    return Icon(icon, size: 24, color: BondlyColors.white);
+  }
+}

--- a/lib/ui/shared/podium_widget.dart
+++ b/lib/ui/shared/podium_widget.dart
@@ -1,0 +1,327 @@
+import 'package:bondly_app/config/colors.dart';
+import 'package:bondly_app/config/dimensions.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+
+class PodiumEntry {
+  final String name;
+  final String? avatarUrl;
+  final int count;
+  final String countLabel;
+
+  const PodiumEntry({
+    required this.name,
+    this.avatarUrl,
+    required this.count,
+    required this.countLabel,
+  });
+}
+
+class PodiumWidget extends StatelessWidget {
+  final PodiumEntry first;
+  final PodiumEntry second;
+  final PodiumEntry third;
+
+  const PodiumWidget({
+    super.key,
+    required this.first,
+    required this.second,
+    required this.third,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<BondlyColorScheme>()!;
+
+    return SizedBox(
+      height: 220,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.paddingScreen,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Expanded(child: _buildSecondPlace(colors)),
+            Expanded(child: _buildFirstPlace(colors)),
+            Expanded(child: _buildThirdPlace(colors)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ─── 1st Place (Center — tallest) ────────────────────────────────────
+
+  Widget _buildFirstPlace(BondlyColorScheme colors) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(LucideIcons.crown, size: 20, color: colors.podiumGold),
+        const SizedBox(height: 4),
+        _buildAvatarStack(
+          entry: first,
+          colors: colors,
+          wrapSize: 64,
+          avatarSize: 60,
+          borderColor: colors.podiumGold,
+          iconSize: 28,
+          iconColor: BondlyColors.white,
+          avatarGradient: AppDimensions.accentGradient(colors),
+          medalColor: colors.podiumGold,
+          medalSize: 22,
+          medalText: '1',
+          medalFontSize: 11,
+          medalX: 21,
+          medalY: 50,
+        ),
+        const SizedBox(height: 6),
+        Text(
+          first.name,
+          textAlign: TextAlign.center,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: GoogleFonts.montserrat(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: colors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          '${first.count} ${first.countLabel}',
+          style: GoogleFonts.montserrat(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color: colors.accent,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Container(
+          height: 72,
+          width: double.infinity,
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.vertical(
+              top: Radius.circular(8),
+            ),
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                colors.accentGradientStart,
+                colors.accentGradientStart.withValues(alpha: 0.06),
+              ],
+            ),
+          ),
+          child: Center(
+            child: Icon(LucideIcons.trophy, size: 28, color: colors.accent),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ─── 2nd Place (Left) ────────────────────────────────────────────────
+
+  Widget _buildSecondPlace(BondlyColorScheme colors) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildAvatarStack(
+          entry: second,
+          colors: colors,
+          wrapSize: 56,
+          avatarSize: 52,
+          borderColor: colors.silver,
+          iconSize: 24,
+          iconColor: colors.textMuted,
+          avatarBg: colors.surfaceElevated,
+          medalColor: colors.silver,
+          medalSize: 20,
+          medalText: '2',
+          medalFontSize: 10,
+          medalX: 18,
+          medalY: 42,
+        ),
+        const SizedBox(height: 6),
+        Text(
+          second.name,
+          textAlign: TextAlign.center,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: GoogleFonts.montserrat(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: colors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          '${second.count} ${second.countLabel}',
+          style: GoogleFonts.montserrat(
+            fontSize: 11,
+            fontWeight: FontWeight.w500,
+            color: colors.textMuted,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Container(
+          height: 56,
+          width: double.infinity,
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.vertical(
+              top: Radius.circular(8),
+            ),
+            color: colors.silver.withValues(alpha: 0.094),
+          ),
+          child: Center(
+            child: Icon(LucideIcons.medal, size: 24, color: colors.silver),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ─── 3rd Place (Right) ───────────────────────────────────────────────
+
+  Widget _buildThirdPlace(BondlyColorScheme colors) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildAvatarStack(
+          entry: third,
+          colors: colors,
+          wrapSize: 52,
+          avatarSize: 48,
+          borderColor: colors.bronze,
+          iconSize: 22,
+          iconColor: colors.textMuted,
+          avatarBg: colors.surfaceElevated,
+          medalColor: colors.bronze,
+          medalSize: 20,
+          medalText: '3',
+          medalFontSize: 10,
+          medalX: 16,
+          medalY: 38,
+        ),
+        const SizedBox(height: 6),
+        Text(
+          third.name,
+          textAlign: TextAlign.center,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: GoogleFonts.montserrat(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: colors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          '${third.count} ${third.countLabel}',
+          style: GoogleFonts.montserrat(
+            fontSize: 11,
+            fontWeight: FontWeight.w500,
+            color: colors.textMuted,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Container(
+          height: 40,
+          width: double.infinity,
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.vertical(
+              top: Radius.circular(8),
+            ),
+            color: colors.bronze.withValues(alpha: 0.094),
+          ),
+          child: Center(
+            child: Icon(LucideIcons.medal, size: 22, color: colors.bronze),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ─── Avatar Stack Helper ─────────────────────────────────────────────
+
+  Widget _buildAvatarStack({
+    required PodiumEntry entry,
+    required BondlyColorScheme colors,
+    required double wrapSize,
+    required double avatarSize,
+    required Color borderColor,
+    required double iconSize,
+    required Color iconColor,
+    Color? avatarBg,
+    Gradient? avatarGradient,
+    required Color medalColor,
+    required double medalSize,
+    required String medalText,
+    required double medalFontSize,
+    required double medalX,
+    required double medalY,
+  }) {
+    final hasAvatar = entry.avatarUrl != null && entry.avatarUrl!.isNotEmpty;
+
+    return SizedBox(
+      width: wrapSize,
+      height: wrapSize,
+      child: Stack(
+        clipBehavior: Clip.none,
+        alignment: Alignment.center,
+        children: [
+          Container(
+            width: avatarSize,
+            height: avatarSize,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: avatarGradient == null ? avatarBg : null,
+              gradient: avatarGradient,
+              border: Border.all(color: borderColor, width: 2.5),
+            ),
+            child: hasAvatar
+                ? ClipOval(
+                    child: Image.network(
+                      entry.avatarUrl!,
+                      width: avatarSize,
+                      height: avatarSize,
+                      fit: BoxFit.cover,
+                    ),
+                  )
+                : Center(
+                    child: Icon(
+                      LucideIcons.user,
+                      size: iconSize,
+                      color: iconColor,
+                    ),
+                  ),
+          ),
+          Positioned(
+            left: medalX,
+            top: medalY,
+            child: Container(
+              width: medalSize,
+              height: medalSize,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: medalColor,
+              ),
+              child: Center(
+                child: Text(
+                  medalText,
+                  style: GoogleFonts.montserrat(
+                    fontSize: medalFontSize,
+                    fontWeight: FontWeight.w800,
+                    color: BondlyColors.white,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/shared/podium_widget.dart
+++ b/lib/ui/shared/podium_widget.dart
@@ -288,6 +288,13 @@ class PodiumWidget extends StatelessWidget {
                       width: avatarSize,
                       height: avatarSize,
                       fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => Center(
+                        child: Icon(
+                          LucideIcons.user,
+                          size: iconSize,
+                          color: iconColor,
+                        ),
+                      ),
                     ),
                   )
                 : Center(

--- a/supabase/migrations/get_ranking.sql
+++ b/supabase/migrations/get_ranking.sql
@@ -20,6 +20,10 @@ RETURNS TABLE (
   recognition_count bigint
 ) AS $$
 BEGIN
+  IF period_filter NOT IN ('month', 'quarter', 'year') THEN
+    RAISE EXCEPTION 'Invalid period_filter: %. Valid values are month, quarter, year.', period_filter;
+  END IF;
+
   RETURN QUERY
   SELECT
     ROW_NUMBER() OVER (ORDER BY COUNT(ar.id) DESC) AS position,
@@ -35,14 +39,7 @@ BEGIN
   WHERE u.visible = true
     AND u.is_active = true
     AND a.visible = true
-    AND (
-      CASE
-        WHEN period_filter = 'month' THEN a.created_at >= date_trunc('month', now())
-        WHEN period_filter = 'quarter' THEN a.created_at >= date_trunc('quarter', now())
-        WHEN period_filter = 'year' THEN a.created_at >= date_trunc('year', now())
-        ELSE true
-      END
-    )
+    AND a.created_at >= date_trunc(period_filter, now())
   GROUP BY u.id, u.complete_name, u.avatar, up.job_position
   ORDER BY recognition_count DESC
   LIMIT result_limit;

--- a/supabase/migrations/get_ranking.sql
+++ b/supabase/migrations/get_ranking.sql
@@ -1,0 +1,50 @@
+-- ============================================================
+-- RPC: get_ranking
+-- Returns the top N users ranked by recognition count
+-- filtered by period (month, quarter, year).
+--
+-- Usage from Supabase client:
+--   .rpc('get_ranking', { 'period_filter': 'month', 'result_limit': 10 })
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION get_ranking(
+  period_filter text DEFAULT 'month',
+  result_limit int DEFAULT 10
+)
+RETURNS TABLE (
+  position bigint,
+  user_id uuid,
+  complete_name text,
+  avatar text,
+  job_position text,
+  recognition_count bigint
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    ROW_NUMBER() OVER (ORDER BY COUNT(ar.id) DESC) AS position,
+    u.id AS user_id,
+    u.complete_name,
+    u.avatar,
+    up.job_position,
+    COUNT(ar.id) AS recognition_count
+  FROM acknowledgment_recipients ar
+  INNER JOIN acknowledgments a ON a.id = ar.acknowledgment_id
+  INNER JOIN users u ON u.id = ar.user_id
+  LEFT JOIN user_profiles up ON up.user_id = u.id
+  WHERE u.visible = true
+    AND u.is_active = true
+    AND a.visible = true
+    AND (
+      CASE
+        WHEN period_filter = 'month' THEN a.created_at >= date_trunc('month', now())
+        WHEN period_filter = 'quarter' THEN a.created_at >= date_trunc('quarter', now())
+        WHEN period_filter = 'year' THEN a.created_at >= date_trunc('year', now())
+        ELSE true
+      END
+    )
+  GROUP BY u.id, u.complete_name, u.avatar, up.job_position
+  ORDER BY recognition_count DESC
+  LIMIT result_limit;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
 ### Summary                                                                              
  - Add full **Ranking screen** with podium (top 3) and list (positions 4-10), period
  filtering (month/quarter/year), and real-time data from Supabase via a new `get_ranking` 
  RPC function.                                             
  - Redesign the **Embajadas tab** to include a slider banner, an inline ranking podium
  preview, and a 2-column badge grid populated from the existing `ambassadors` + `badges`
  tables.
  - Create reusable **PodiumWidget** and **BadgeCard** shared components.
  - Ranking feature is **hidden when `BACKEND=api`** in `.env` and only loads data when the
   backend is Supabase or any non-API value.

  ### New files
  | File | Purpose |
  |------|---------|
  | `supabase/migrations/get_ranking.sql` | PostgreSQL RPC `get_ranking(period_filter,
  result_limit)` |
  | `lib/features/ranking/domain/repositories/ranking_repository.dart` | Abstract
  repository interface |
  | `lib/features/ranking/data/repositories/supabase_ranking_repository.dart` | Supabase
  `.rpc()` implementation |
  | `lib/features/ranking/domain/usecases/get_ranking_usecase.dart` | Use case |
  | `lib/features/ranking/domain/models/ranked_user.dart` | `RankedUser` model with
  `fromSupabase` factory |
  | `lib/features/ranking/ui/viewmodels/ranking_viewmodel.dart` | ViewModel for the full
  ranking screen |
  | `lib/features/ranking/ui/screens/ranking_screen.dart` | Full ranking screen with period
   tabs |
  | `lib/ui/shared/podium_widget.dart` | Reusable podium widget (1st/2nd/3rd) |
  | `lib/ui/shared/badge_card.dart` | Reusable badge card with gradient + icon/image |
  | `lib/config/strings_ranking.dart` | Ranking string constants |

  ### Modified files
  | File | Change |
  |------|--------|
  | `lib/config/backend_config.dart` | Added `isApi` getter |
  | `lib/config/colors.dart` | Added podium gold/silver/bronze color tokens |
  | `lib/config/strings_home.dart` | Added embassy section strings |
  | `lib/features/home/ui/viewmodels/home_viewmodel.dart` | Added `GetRankingUseCase`,
  `rankingUsers`, `isRankingEnabled` |
  | `lib/features/home/ui/screens/ambassadors_tab.dart` | Full rewrite: slider +
  conditional ranking + badge grid + skeleton |
  | `lib/dependencies/repository_provider.dart` | Registered `RankingRepository` |
  | `lib/dependencies/usecase_provider.dart` | Registered `GetRankingUseCase` |
  | `lib/dependencies/viewmodel_provider.dart` | Registered `RankingViewModel`, updated
  `HomeViewModel` constructor |
  | `lib/src/routes.dart` | Added `/rankingScreen` route |

  ### Setup required
  Run the SQL in `supabase/migrations/get_ranking.sql` in the Supabase SQL Editor before
  testing.

  ### Test plan
  - [ ] Set `BACKEND=supabase` in `.env` — ranking section should appear in the Embajadas
  tab and load real data
  - [ ] Set `BACKEND=api` in `.env` — ranking section and skeleton should be completely
  hidden
  - [ ] Open Ranking screen via "Ver todo" — verify period tabs switch data correctly
  - [ ] Verify empty state when there are no acknowledgments in the selected period
  - [ ] Verify badge grid renders correctly with category-based gradients
  - [ ] Verify light and dark theme support across all new components

## Evicence
|Ranking|Top 3 And Embassy list |
|---|---|
|<img width="563" height="1256" alt="image" src="https://github.com/user-attachments/assets/7f03933a-ee6c-417e-872f-9c28d5ce6adc" />|<img width="563" height="1256" alt="image" src="https://github.com/user-attachments/assets/72197eea-28c4-4d82-a844-5f9d2ce128ab" />|