### PR TITLE
[FEAT] Redesign Mi Actividad & Activity Detail screens

### DIFF
--- a/lib/features/home/ui/screens/tab_feed.dart
+++ b/lib/features/home/ui/screens/tab_feed.dart
@@ -6,13 +6,12 @@ import 'package:bondly_app/features/home/domain/models/company_feed_model.dart';
 import 'package:bondly_app/features/home/ui/viewmodels/home_viewmodel.dart';
 import 'package:bondly_app/features/home/ui/widgets/post_mentions_widget.dart';
 import 'package:bondly_app/src/network_image_helpers.dart';
-import 'package:bondly_app/ui/shared/badge_icon_button.dart';
 import 'package:bondly_app/ui/shared/feed_post_card.dart';
+import 'package:bondly_app/ui/shared/feed_post_helpers.dart';
 import 'package:bondly_app/ui/shared/slider_banner_card.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:lucide_icons/lucide_icons.dart';
-import 'package:moment_dart/moment_dart.dart';
 
 class FeedTab extends StatefulWidget {
   final HomeViewModel model;
@@ -175,7 +174,7 @@ class _FeedTabState extends State<FeedTab> {
   // ─── Post Card ────────────────────────────────────────────────────────
 
   Widget _buildPostCard(FeedData post, int index, BondlyColorScheme colors) {
-    final badgeType = _resolveBadgeType(post.type);
+    final badgeType = FeedPostHelpers.resolveBadgeType(post.type);
     final postId = post.id ?? index.toString();
 
     // Ensure a controller exists for this post
@@ -187,7 +186,7 @@ class _FeedTabState extends State<FeedTab> {
         .map((c) => FeedCommentData(
               userName: c.user.completeName.trim(),
               userAvatarUrl: safeImageUrl(c.user.avatar, isAvatar: true),
-              timeAgo: _formatTimeAgo(c.timeStamp),
+              timeAgo: FeedPostHelpers.formatTimeAgo(c.timeStamp),
               message: c.message ?? '',
             ))
         .toList();
@@ -197,12 +196,12 @@ class _FeedTabState extends State<FeedTab> {
     return FeedPostCard(
       // Badge
       badgeName: post.badge?.name,
-      badgeCategory: _resolveBadgeCategory(post.type),
+      badgeCategory: FeedPostHelpers.resolveBadgeCategory(post.type),
       badgeType: badgeType,
       // Author
       userName: post.sender.completeName.trim(),
       userAvatarUrl: safeImageUrl(post.sender.avatar, isAvatar: true),
-      date: _formatDate(post.createdAt),
+      date: FeedPostHelpers.formatDate(post.createdAt),
       tag: StringsHome.feedTagRecognition,
       // Content
       message: post.body,
@@ -288,37 +287,4 @@ class _FeedTabState extends State<FeedTab> {
     }
   }
 
-  static BadgeType _resolveBadgeType(String type) {
-    final lower = type.toLowerCase();
-    if (lower.contains('especial')) return BadgeType.especiales;
-    if (lower.contains('valor') || lower.contains('embajada')) {
-      return BadgeType.valores;
-    }
-    return BadgeType.competencias;
-  }
-
-  static String _resolveBadgeCategory(String type) {
-    final lower = type.toLowerCase();
-    if (lower.contains('especial')) return StringsHome.badgeEspeciales;
-    if (lower.contains('valor') || lower.contains('embajada')) {
-      return StringsHome.badgeValores;
-    }
-    return StringsHome.badgeCompetencias;
-  }
-
-  static String _formatDate(DateTime date) {
-    final moment = Moment(date.toLocal());
-    return moment.format('DD MMM YYYY');
-  }
-
-  static String _formatTimeAgo(String? timestamp) {
-    if (timestamp == null) return '';
-    try {
-      final date = DateTime.parse(timestamp);
-      final moment = Moment(date.toLocal());
-      return moment.fromNow(dropPrefixOrSuffix: true);
-    } catch (_) {
-      return '';
-    }
-  }
 }

--- a/lib/features/profile/ui/screens/activity_detail_screen.dart
+++ b/lib/features/profile/ui/screens/activity_detail_screen.dart
@@ -1,13 +1,22 @@
+import 'package:bondly_app/config/colors.dart';
 import 'package:bondly_app/config/dimensions.dart';
+import 'package:bondly_app/config/strings_home.dart';
 import 'package:bondly_app/config/strings_profile.dart';
 import 'package:bondly_app/dependencies/dependency_manager.dart';
 import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
-import 'package:bondly_app/features/home/ui/widgets/single_post_widget.dart';
+import 'package:bondly_app/features/home/domain/models/company_feed_model.dart';
+import 'package:bondly_app/features/home/ui/viewmodels/home_viewmodel.dart';
+import 'package:bondly_app/features/home/ui/widgets/post_mentions_widget.dart';
 import 'package:bondly_app/features/profile/ui/viewmodels/activity_detail_viewmodel.dart';
-import 'package:bondly_app/ui/shared/app_sliver_layout.dart';
+import 'package:bondly_app/src/network_image_helpers.dart';
+import 'package:bondly_app/ui/shared/badge_icon_button.dart';
 import 'package:bondly_app/ui/shared/bondly_skeleton.dart';
-import 'package:ficonsax/ficonsax.dart';
+import 'package:bondly_app/ui/shared/feed_post_card.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:moment_dart/moment_dart.dart';
 
 class ActivityDetailScreen extends StatefulWidget {
   static const String route = "/activityDetailScreen";
@@ -32,6 +41,11 @@ class ActivityDetailScreen extends StatefulWidget {
 }
 
 class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
+  bool _likeBusy = false;
+  bool _commentsExpanded = false;
+  bool _commentBusy = false;
+  final TextEditingController _commentController = TextEditingController();
+
   @override
   void initState() {
     super.initState();
@@ -39,70 +53,276 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    var theme = Theme.of(context);
-    return ModelProvider<ActivityDetailViewModel>(
-        model: widget.model,
-        child: ModelBuilder<ActivityDetailViewModel>(
-            builder: (context, model, child) {
-          return Scaffold(
-            backgroundColor: theme.scaffoldBackgroundColor,
-            body: SafeArea(
-              child: BondlySliverLayout(
-                  title: "",
-                  child: model.post != null && !model.busy
-                      ? Container(
-                          margin: const EdgeInsets.symmetric(horizontal: 16.0),
-                          child: Column(
-                            children: [
-                              SinglePostWidget(post: model.post!, index: 0)
-                            ],
-                          ))
-                      : (model.busy
-                          ? _showLoading()
-                          : _showNoConnectionError())),
-            ),
-          );
-        }));
+  void dispose() {
+    _commentController.dispose();
+    super.dispose();
   }
 
-  Widget _showLoading() {
-    return const Center(
-      child: BondlyShimmerBlock(width: 200, height: 200, borderRadius: 12),
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<BondlyColorScheme>()!;
+
+    return ModelProvider<ActivityDetailViewModel>(
+      model: widget.model,
+      child: ModelBuilder<ActivityDetailViewModel>(
+        builder: (context, model, child) {
+          return Scaffold(
+            backgroundColor: colors.bg,
+            body: Column(
+              children: [
+                _buildHeader(colors),
+                Expanded(
+                  child: model.post != null && !model.busy
+                      ? _buildPostContent(model.post!, colors)
+                      : model.busy
+                          ? _buildLoading()
+                          : _buildErrorState(colors),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
     );
   }
 
-  Widget _showNoConnectionError() {
-    return Container(
-      decoration: BoxDecoration(
-        border: Border.all(color: Theme.of(context).cardColor),
-        color: Theme.of(context).dividerColor,
-        borderRadius: BorderRadius.circular(AppDimensions.radiusLg),
-        boxShadow:
-            AppDimensions.cardShadow(Theme.of(context).colorScheme.onSurface),
-      ),
-      margin: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 32.0),
-      width: double.infinity,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            IconsaxBold.forbidden_2,
-            color: Theme.of(context).unselectedWidgetColor,
-            size: 64.0,
+  Widget _buildHeader(BondlyColorScheme colors) {
+    return SafeArea(
+      bottom: false,
+      child: SizedBox(
+        height: 56,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppDimensions.paddingScreen,
           ),
-          Container(
-            margin:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
-            child: Text(
-              StringsProfile.myActivityLoadError,
-              style: Theme.of(context).textTheme.headlineSmall,
-              textAlign: TextAlign.center,
-            ),
-          )
+          child: Row(
+            children: [
+              GestureDetector(
+                onTap: () => context.pop(),
+                child: Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: colors.surfaceElevated,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    LucideIcons.arrowLeft,
+                    size: 24,
+                    color: colors.textPrimary,
+                  ),
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  StringsProfile.myActivity,
+                  textAlign: TextAlign.center,
+                  style: GoogleFonts.montserrat(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                    color: colors.textPrimary,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 24),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPostContent(FeedData post, BondlyColorScheme colors) {
+    final badgeType = _resolveBadgeType(post.type);
+    final homeModel = getIt<HomeViewModel>();
+    final currentUserAvatar = homeModel.user?.avatar;
+
+    final previewComments = post.comments
+        .take(2)
+        .map((c) => FeedCommentData(
+              userName: c.user.completeName.trim(),
+              userAvatarUrl: safeImageUrl(c.user.avatar, isAvatar: true),
+              timeAgo: _formatTimeAgo(c.timeStamp),
+              message: c.message ?? '',
+            ))
+        .toList();
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.paddingScreen,
+        vertical: AppDimensions.spacingSm,
+      ),
+      child: FeedPostCard(
+        badgeName: post.badge?.name,
+        badgeCategory: _resolveBadgeCategory(post.type),
+        badgeType: badgeType,
+        userName: post.sender.completeName.trim(),
+        userAvatarUrl: safeImageUrl(post.sender.avatar, isAvatar: true),
+        date: _formatDate(post.createdAt),
+        tag: StringsHome.feedTagRecognition,
+        message: post.body,
+        mentionWidget: PostMentionsWidget(
+          text: post.body,
+          style: GoogleFonts.montserrat(
+            fontSize: 13,
+            color: colors.textSecondary,
+            height: 1.5,
+          ),
+        ),
+        likeCount: post.likes.length,
+        commentCount: post.comments.length,
+        isLiked: post.isLiked ?? false,
+        isLikeBusy: _likeBusy,
+        onLikeTap: () => _handleLike(post),
+        onCommentTap: post.comments.isNotEmpty
+            ? () {
+                setState(() {
+                  _commentsExpanded = !_commentsExpanded;
+                });
+              }
+            : null,
+        showComments: _commentsExpanded,
+        commentsPreview: previewComments,
+        currentUserAvatarUrl:
+            currentUserAvatar != null && currentUserAvatar.isNotEmpty
+                ? safeImageUrl(currentUserAvatar, isAvatar: true)
+                : null,
+        commentController: _commentController,
+        isCommentBusy: _commentBusy,
+        onSendComment: () => _handleSendComment(post),
+      ),
+    );
+  }
+
+  Widget _buildLoading() {
+    return const Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: AppDimensions.paddingScreen,
+        vertical: AppDimensions.spacingXl,
+      ),
+      child: Column(
+        children: [
+          BondlyShimmerBlock(
+            width: double.infinity,
+            height: 100,
+            borderRadius: 20,
+          ),
+          SizedBox(height: 12),
+          BondlyShimmerBlock(
+            width: double.infinity,
+            height: 80,
+            borderRadius: 16,
+          ),
+          SizedBox(height: 12),
+          BondlyShimmerBlock(
+            width: double.infinity,
+            height: 48,
+            borderRadius: 12,
+          ),
         ],
       ),
     );
+  }
+
+  Widget _buildErrorState(BondlyColorScheme colors) {
+    return Center(
+      child: Container(
+        margin: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.paddingScreen,
+        ),
+        padding: const EdgeInsets.all(AppDimensions.spacingXxl),
+        decoration: BoxDecoration(
+          color: colors.surface,
+          border: Border.all(color: colors.border),
+          borderRadius: BorderRadius.circular(AppDimensions.radiusCard),
+          boxShadow: AppDimensions.cardShadow(colors.textPrimary),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              LucideIcons.alertCircle,
+              color: colors.textMuted,
+              size: 48,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              StringsProfile.myActivityLoadError,
+              style: GoogleFonts.montserrat(
+                fontSize: 15,
+                fontWeight: FontWeight.w500,
+                color: colors.textSecondary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ─── Interaction Handlers ──────────────────────────────────────────
+
+  Future<void> _handleLike(FeedData post) async {
+    final postId = post.id;
+    if (postId == null) return;
+
+    setState(() => _likeBusy = true);
+    try {
+      await getIt<HomeViewModel>().handleLikes(postId);
+    } finally {
+      if (mounted) setState(() => _likeBusy = false);
+    }
+  }
+
+  Future<void> _handleSendComment(FeedData post) async {
+    if (_commentController.text.trim().isEmpty) return;
+    final postId = post.id;
+    if (postId == null) return;
+
+    final text = _commentController.text.trim();
+    setState(() => _commentBusy = true);
+    try {
+      await getIt<HomeViewModel>().createComment(postId, text, 0);
+      _commentController.clear();
+    } finally {
+      if (mounted) setState(() => _commentBusy = false);
+    }
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────────
+
+  static BadgeType _resolveBadgeType(String type) {
+    final lower = type.toLowerCase();
+    if (lower.contains('especial')) return BadgeType.especiales;
+    if (lower.contains('valor') || lower.contains('embajada')) {
+      return BadgeType.valores;
+    }
+    return BadgeType.competencias;
+  }
+
+  static String _resolveBadgeCategory(String type) {
+    final lower = type.toLowerCase();
+    if (lower.contains('especial')) return StringsHome.badgeEspeciales;
+    if (lower.contains('valor') || lower.contains('embajada')) {
+      return StringsHome.badgeValores;
+    }
+    return StringsHome.badgeCompetencias;
+  }
+
+  static String _formatDate(DateTime date) {
+    final moment = Moment(date.toLocal());
+    return moment.format('DD MMM YYYY');
+  }
+
+  static String _formatTimeAgo(String? timestamp) {
+    if (timestamp == null) return '';
+    try {
+      final date = DateTime.parse(timestamp);
+      final moment = Moment(date.toLocal());
+      return moment.fromNow(dropPrefixOrSuffix: true);
+    } catch (_) {
+      return '';
+    }
   }
 }

--- a/lib/features/profile/ui/screens/activity_detail_screen.dart
+++ b/lib/features/profile/ui/screens/activity_detail_screen.dart
@@ -9,14 +9,13 @@ import 'package:bondly_app/features/home/ui/viewmodels/home_viewmodel.dart';
 import 'package:bondly_app/features/home/ui/widgets/post_mentions_widget.dart';
 import 'package:bondly_app/features/profile/ui/viewmodels/activity_detail_viewmodel.dart';
 import 'package:bondly_app/src/network_image_helpers.dart';
-import 'package:bondly_app/ui/shared/badge_icon_button.dart';
 import 'package:bondly_app/ui/shared/bondly_skeleton.dart';
 import 'package:bondly_app/ui/shared/feed_post_card.dart';
+import 'package:bondly_app/ui/shared/feed_post_helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:lucide_icons/lucide_icons.dart';
-import 'package:moment_dart/moment_dart.dart';
 
 class ActivityDetailScreen extends StatefulWidget {
   static const String route = "/activityDetailScreen";
@@ -113,6 +112,7 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
                   ),
                 ),
               ),
+              const SizedBox(width: 10),
               Expanded(
                 child: Text(
                   StringsProfile.myActivity,
@@ -124,7 +124,7 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
                   ),
                 ),
               ),
-              const SizedBox(width: 24),
+              const SizedBox(width: 36),
             ],
           ),
         ),
@@ -133,7 +133,7 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
   }
 
   Widget _buildPostContent(FeedData post, BondlyColorScheme colors) {
-    final badgeType = _resolveBadgeType(post.type);
+    final badgeType = FeedPostHelpers.resolveBadgeType(post.type);
     final homeModel = getIt<HomeViewModel>();
     final currentUserAvatar = homeModel.user?.avatar;
 
@@ -142,7 +142,7 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
         .map((c) => FeedCommentData(
               userName: c.user.completeName.trim(),
               userAvatarUrl: safeImageUrl(c.user.avatar, isAvatar: true),
-              timeAgo: _formatTimeAgo(c.timeStamp),
+              timeAgo: FeedPostHelpers.formatTimeAgo(c.timeStamp),
               message: c.message ?? '',
             ))
         .toList();
@@ -154,11 +154,11 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
       ),
       child: FeedPostCard(
         badgeName: post.badge?.name,
-        badgeCategory: _resolveBadgeCategory(post.type),
+        badgeCategory: FeedPostHelpers.resolveBadgeCategory(post.type),
         badgeType: badgeType,
         userName: post.sender.completeName.trim(),
         userAvatarUrl: safeImageUrl(post.sender.avatar, isAvatar: true),
-        date: _formatDate(post.createdAt),
+        date: FeedPostHelpers.formatDate(post.createdAt),
         tag: StringsHome.feedTagRecognition,
         message: post.body,
         mentionWidget: PostMentionsWidget(
@@ -270,6 +270,7 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
     setState(() => _likeBusy = true);
     try {
       await getIt<HomeViewModel>().handleLikes(postId);
+      await widget.model.load(widget.feedId, widget.activityId, widget.isRead);
     } finally {
       if (mounted) setState(() => _likeBusy = false);
     }
@@ -285,44 +286,10 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
     try {
       await getIt<HomeViewModel>().createComment(postId, text, 0);
       _commentController.clear();
+      await widget.model.load(widget.feedId, widget.activityId, widget.isRead);
     } finally {
       if (mounted) setState(() => _commentBusy = false);
     }
   }
 
-  // ─── Helpers ───────────────────────────────────────────────────────
-
-  static BadgeType _resolveBadgeType(String type) {
-    final lower = type.toLowerCase();
-    if (lower.contains('especial')) return BadgeType.especiales;
-    if (lower.contains('valor') || lower.contains('embajada')) {
-      return BadgeType.valores;
-    }
-    return BadgeType.competencias;
-  }
-
-  static String _resolveBadgeCategory(String type) {
-    final lower = type.toLowerCase();
-    if (lower.contains('especial')) return StringsHome.badgeEspeciales;
-    if (lower.contains('valor') || lower.contains('embajada')) {
-      return StringsHome.badgeValores;
-    }
-    return StringsHome.badgeCompetencias;
-  }
-
-  static String _formatDate(DateTime date) {
-    final moment = Moment(date.toLocal());
-    return moment.format('DD MMM YYYY');
-  }
-
-  static String _formatTimeAgo(String? timestamp) {
-    if (timestamp == null) return '';
-    try {
-      final date = DateTime.parse(timestamp);
-      final moment = Moment(date.toLocal());
-      return moment.fromNow(dropPrefixOrSuffix: true);
-    } catch (_) {
-      return '';
-    }
-  }
 }

--- a/lib/features/profile/ui/screens/my_activity_screen.dart
+++ b/lib/features/profile/ui/screens/my_activity_screen.dart
@@ -3,15 +3,14 @@ import 'package:bondly_app/config/dimensions.dart';
 import 'package:bondly_app/config/strings_profile.dart';
 import 'package:bondly_app/dependencies/dependency_manager.dart';
 import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
-import 'package:bondly_app/features/profile/domain/models/user_activity.dart';
 import 'package:bondly_app/features/profile/ui/screens/activity_detail_screen.dart';
 import 'package:bondly_app/features/profile/ui/viewmodels/my_activity_viewmodel.dart';
 import 'package:bondly_app/features/profile/ui/widgets/user_activity_item.dart';
-import 'package:bondly_app/ui/shared/app_body_layout.dart';
 import 'package:bondly_app/ui/shared/bondly_skeleton.dart';
-import 'package:ficonsax/ficonsax.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:lucide_icons/lucide_icons.dart';
 
 class MyActivityScreen extends StatefulWidget {
   static const String route = "/myActivityScreen";
@@ -25,9 +24,6 @@ class MyActivityScreen extends StatefulWidget {
 class _MyActivityScreenState extends State<MyActivityScreen>
     with AutomaticKeepAliveClientMixin<MyActivityScreen> {
   late MyActivityViewModel _viewModel;
-  bool addMargin = false;
-
-  double top = 0.0;
 
   @override
   bool get wantKeepAlive => true;
@@ -42,189 +38,245 @@ class _MyActivityScreenState extends State<MyActivityScreen>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    var theme = Theme.of(context);
+    final colors = Theme.of(context).extension<BondlyColorScheme>()!;
 
-    return Scaffold(
-      backgroundColor: theme.scaffoldBackgroundColor,
-      body: _buildBody(theme),
+    return ModelProvider<MyActivityViewModel>(
+      model: _viewModel,
+      child: ModelBuilder<MyActivityViewModel>(
+        builder: (context, model, child) {
+          return Scaffold(
+            backgroundColor: colors.bg,
+            body: Stack(
+              children: [
+                Column(
+                  children: [
+                    _buildHeader(colors),
+                    Expanded(
+                      child: _buildContent(model, colors),
+                    ),
+                  ],
+                ),
+                if (!model.errorShown &&
+                    model.notificationMessage.isNotEmpty)
+                  _buildNotificationToast(model, colors),
+              ],
+            ),
+          );
+        },
+      ),
     );
   }
 
-  Widget _buildBody(ThemeData theme) {
-    final colors = theme.extension<BondlyColorScheme>()!;
-    return ModelProvider<MyActivityViewModel>(
-        model: _viewModel,
-        child: ModelBuilder<MyActivityViewModel>(
-            builder: (context, model, widget) {
-          var length = model.activities.length + (model.nextPage > -1 ? 1 : 0);
-          return Stack(
+  Widget _buildHeader(BondlyColorScheme colors) {
+    return SafeArea(
+      bottom: false,
+      child: SizedBox(
+        height: 56,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppDimensions.paddingScreen,
+          ),
+          child: Row(
             children: [
-              NestedScrollView(
-                  headerSliverBuilder:
-                      (BuildContext context, bool innerBoxIsScrolled) {
-                    return <Widget>[
-                      SliverAppBar(
-                          leading: IconButton(
-                            onPressed: () => context.pop(),
-                            tooltip: 'Regresar',
-                            icon: const Icon(
-                              IconsaxOutline.arrow_left,
-                            ),
-                          ),
-                          backgroundColor: theme.scaffoldBackgroundColor,
-                          iconTheme: IconThemeData(
-                            color: theme.unselectedWidgetColor,
-                          ),
-                          expandedHeight: 260.0,
-                          floating: false,
-                          pinned: true,
-                          flexibleSpace: LayoutBuilder(
-                            builder: (context, constraints) {
-                              top = constraints.biggest.height;
-
-                              return FlexibleSpaceBar(
-                                centerTitle: true,
-                                background: SafeArea(
-                                  child: Padding(
-                                    padding: const EdgeInsets.only(top: 44.0),
-                                    child: BodyLayout(
-                                      enableBanners: true,
-                                      child: Container(),
-                                    ),
-                                  ),
-                                ),
-                                title: top < 120.0
-                                    ? Text(
-                                        StringsProfile.myActivity,
-                                        style: theme.textTheme.titleLarge,
-                                      )
-                                    : const SizedBox(),
-                              );
-                            },
-                          )),
-                    ];
-                  },
-                  body: NotificationListener<ScrollEndNotification>(
-                    onNotification: (notification) {
-                      var metrics = notification.metrics;
-                      if (metrics.atEdge && metrics.pixels > 0) {
-                        model.loadActivity();
-                      }
-
-                      return true;
-                    },
-                    child: Container(
-                      margin: const EdgeInsets.only(bottom: 24.0),
-                      child: ListView.builder(
-                          padding: const EdgeInsets.only(top: 16.0),
-                          itemCount: length,
-                          itemBuilder: (context, index) {
-                            if (index < model.activities.length) {
-                              var item = model.activities[index];
-
-                              if (index == 0) {
-                                return Column(
-                                  children: [
-                                    _buildHeaderCard(theme),
-                                    _buildActivityItem(item)
-                                  ],
-                                );
-                              }
-
-                              return _buildActivityItem(item);
-                            }
-
-                            return Container(
-                                margin: const EdgeInsets.only(top: 16),
-                                child: model.notificationMessage.isEmpty &&
-                                        model.busy
-                                    ? const Center(
-                                        child: BondlyShimmerBlock(
-                                            width: 40,
-                                            height: 40,
-                                            borderRadius: 20))
-                                    : Container());
-                          }),
-                    ),
-                  )),
-              !model.errorShown && model.notificationMessage.isNotEmpty
-                  ? Positioned(
-                      bottom: 24.0,
-                      left: 0,
-                      right: 0,
-                      child: Container(
-                        padding: const EdgeInsets.all(8.0),
-                        margin: const EdgeInsets.symmetric(
-                            horizontal: 24.0, vertical: 16.0),
-                        decoration: BoxDecoration(
-                            color: theme.dividerColor,
-                            border: Border.all(color: colors.likeColor),
-                            borderRadius:
-                                BorderRadius.circular(AppDimensions.radiusLg)),
-                        child: Text(
-                          model.notificationMessage,
-                          style: theme.textTheme.bodyLarge!
-                              .copyWith(fontSize: 18.0),
-                          textAlign: TextAlign.center,
-                        ),
-                      ))
-                  : Container()
+              GestureDetector(
+                onTap: () => context.pop(),
+                child: Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: colors.surfaceElevated,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    LucideIcons.arrowLeft,
+                    size: 24,
+                    color: colors.textPrimary,
+                  ),
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  StringsProfile.myActivity,
+                  textAlign: TextAlign.center,
+                  style: GoogleFonts.montserrat(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                    color: colors.textPrimary,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 24),
             ],
-          );
-        }));
+          ),
+        ),
+      ),
+    );
   }
 
-  Widget _buildHeaderCard(ThemeData theme) {
-    final colors = theme.extension<BondlyColorScheme>()!;
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16.0),
-      margin: const EdgeInsets.only(
-        left: 12.0,
-        right: 12.0,
+  Widget _buildContent(MyActivityViewModel model, BondlyColorScheme colors) {
+    if (model.activities.isEmpty && model.busy) {
+      return _buildSkeletonList(colors);
+    }
+
+    final itemCount =
+        model.activities.length + (model.nextPage > -1 ? 1 : 0);
+
+    return NotificationListener<ScrollEndNotification>(
+      onNotification: (notification) {
+        final metrics = notification.metrics;
+        if (metrics.atEdge && metrics.pixels > 0) {
+          model.loadActivity();
+        }
+        return true;
+      },
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(
+          vertical: AppDimensions.spacingSm,
+          horizontal: AppDimensions.paddingScreen,
+        ),
+        itemCount: itemCount + 1, // +1 for the info banner at index 0
+        itemBuilder: (context, index) {
+          if (index == 0) {
+            return _buildInfoBanner(colors);
+          }
+
+          final activityIndex = index - 1;
+
+          if (activityIndex < model.activities.length) {
+            final item = model.activities[activityIndex];
+            return UserActivityItemWidget(
+              key: Key(item.id),
+              id: item.feedId,
+              type: item.type,
+              title: item.title,
+              description: item.content,
+              date: item.createdAt,
+              read: item.read,
+              onTap: () {
+                context.push(ActivityDetailScreen.route, extra: {
+                  ActivityDetailScreen.idParam: item.id,
+                  ActivityDetailScreen.feedIdParam: item.feedId,
+                  ActivityDetailScreen.readParam: item.read,
+                });
+                if (!item.read) {
+                  item.read = true;
+                  setState(() {});
+                }
+              },
+            );
+          }
+
+          // Pagination loading indicator
+          if (model.notificationMessage.isEmpty && model.busy) {
+            return const Padding(
+              padding: EdgeInsets.symmetric(vertical: 16),
+              child: Center(
+                child: BondlyShimmerBlock(
+                  width: 40,
+                  height: 40,
+                  borderRadius: 20,
+                ),
+              ),
+            );
+          }
+
+          return const SizedBox.shrink();
+        },
       ),
+    );
+  }
+
+  Widget _buildInfoBanner(BondlyColorScheme colors) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-          gradient: AppDimensions.accentGradient(colors),
-          borderRadius: const BorderRadius.all(Radius.circular(20.0))),
+        gradient: AppDimensions.accentGradient(colors),
+        borderRadius: BorderRadius.circular(AppDimensions.radiusPost),
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
             StringsProfile.myActivityHeader,
-            style:
-                theme.textTheme.titleLarge!.copyWith(color: BondlyColors.white),
+            style: GoogleFonts.montserrat(
+              fontSize: 17,
+              fontWeight: FontWeight.w700,
+              color: BondlyColors.white,
+            ),
           ),
-          const SizedBox(height: 12.0),
+          const SizedBox(height: 8),
           Text(
             StringsProfile.myActivitySubHeader,
-            style: theme.textTheme.labelLarge!.copyWith(
-                height: 1.4, fontSize: 16.0, color: BondlyColors.white),
-          )
+            style: GoogleFonts.montserrat(
+              fontSize: 13,
+              fontWeight: FontWeight.w400,
+              color: const Color(0xCCFFFFFF),
+              height: 1.5,
+            ),
+          ),
         ],
       ),
     );
   }
 
-  UserActivityItemWidget _buildActivityItem(UserActivityItem item) {
-    return UserActivityItemWidget(
-        key: Key(item.id),
-        id: item.feedId,
-        type: item.type,
-        title: item.title,
-        description: item.content,
-        date: item.createdAt,
-        read: item.read,
-        onTap: () {
-          context.push(ActivityDetailScreen.route, extra: {
-            ActivityDetailScreen.idParam: item.id,
-            ActivityDetailScreen.feedIdParam: item.feedId,
-            ActivityDetailScreen.readParam: item.read
-          });
+  Widget _buildSkeletonList(BondlyColorScheme colors) {
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(
+        vertical: AppDimensions.spacingSm,
+        horizontal: AppDimensions.paddingScreen,
+      ),
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: 5,
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          return Container(
+            margin: const EdgeInsets.only(bottom: 12),
+            child: const BondlyShimmerBlock(
+              width: double.infinity,
+              height: 140,
+              borderRadius: 20,
+            ),
+          );
+        }
+        return Container(
+          margin: const EdgeInsets.only(bottom: 12),
+          child: const BondlyShimmerBlock(
+            width: double.infinity,
+            height: 120,
+            borderRadius: 16,
+          ),
+        );
+      },
+    );
+  }
 
-          if (!item.read) {
-            item.read = true;
-            setState(() {});
-          }
-        });
+  Widget _buildNotificationToast(
+    MyActivityViewModel model,
+    BondlyColorScheme colors,
+  ) {
+    return Positioned(
+      bottom: 24,
+      left: AppDimensions.paddingScreen,
+      right: AppDimensions.paddingScreen,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: colors.surfaceElevated,
+          border: Border.all(color: colors.border),
+          borderRadius: BorderRadius.circular(AppDimensions.radiusCard),
+          boxShadow: AppDimensions.cardShadow(colors.textPrimary),
+        ),
+        child: Text(
+          model.notificationMessage,
+          style: GoogleFonts.montserrat(
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+            color: colors.textSecondary,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/profile/ui/screens/my_activity_screen.dart
+++ b/lib/features/profile/ui/screens/my_activity_screen.dart
@@ -94,6 +94,7 @@ class _MyActivityScreenState extends State<MyActivityScreen>
                   ),
                 ),
               ),
+              const SizedBox(width: 10),
               Expanded(
                 child: Text(
                   StringsProfile.myActivity,
@@ -105,7 +106,7 @@ class _MyActivityScreenState extends State<MyActivityScreen>
                   ),
                 ),
               ),
-              const SizedBox(width: 24),
+              const SizedBox(width: 36),
             ],
           ),
         ),

--- a/lib/features/profile/ui/widgets/user_activity_item.dart
+++ b/lib/features/profile/ui/widgets/user_activity_item.dart
@@ -1,7 +1,9 @@
 import 'package:bondly_app/config/colors.dart';
+import 'package:bondly_app/config/dimensions.dart';
 import 'package:bondly_app/features/home/ui/widgets/post_mentions_widget.dart';
-import 'package:ficonsax/ficonsax.dart';
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:lucide_icons/lucide_icons.dart';
 
 class UserActivityItemWidget extends StatelessWidget {
   final String id;
@@ -12,104 +14,205 @@ class UserActivityItemWidget extends StatelessWidget {
   final bool read;
   final VoidCallback onTap;
 
-  const UserActivityItemWidget(
-      {super.key,
-      required this.id,
-      required this.type,
-      required this.title,
-      required this.description,
-      required this.date,
-      required this.read,
-      required this.onTap});
+  const UserActivityItemWidget({
+    super.key,
+    required this.id,
+    required this.type,
+    required this.title,
+    required this.description,
+    required this.date,
+    required this.read,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<BondlyColorScheme>()!;
-    var theme = Theme.of(context);
-    IconData icon;
+
+    final card = GestureDetector(
+      onTap: onTap,
+      child: read ? _buildReadCard(colors) : _buildUnreadCard(colors),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: card,
+    );
+  }
+
+  Widget _buildUnreadCard(BondlyColorScheme colors) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppDimensions.radiusCard),
+      child: Container(
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(AppDimensions.radiusCard),
+          border: Border.all(color: colors.accent, width: 1),
+        ),
+        child: IntrinsicHeight(
+          child: Row(
+            children: [
+              Container(width: 2, color: colors.accent),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: _buildCardContent(colors),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildReadCard(BondlyColorScheme colors) {
+    return Opacity(
+      opacity: 0.7,
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: colors.surfaceElevated,
+          borderRadius: BorderRadius.circular(AppDimensions.radiusCard),
+          border: Border.all(color: colors.border, width: 1),
+        ),
+        child: _buildCardContent(colors),
+      ),
+    );
+  }
+
+  Widget _buildCardContent(BondlyColorScheme colors) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header row: title + type icon
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Text(
+                title,
+                style: GoogleFonts.montserrat(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  color: colors.textPrimary,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            _buildTypeIcon(colors),
+          ],
+        ),
+        const SizedBox(height: 10),
+
+        // Message
+        PostMentionsWidget(
+          text: description,
+          style: GoogleFonts.montserrat(
+            fontSize: 13,
+            fontWeight: FontWeight.w400,
+            color: colors.textSecondary,
+            height: 1.4,
+          ),
+        ),
+        const SizedBox(height: 10),
+
+        // Date row
+        _buildDateRow(colors),
+      ],
+    );
+  }
+
+  Widget _buildTypeIcon(BondlyColorScheme colors) {
+    final IconData icon;
+    final LinearGradient gradient;
+
     switch (type) {
       case "Reconocimientos":
-        icon = IconsaxBold.medal_star;
+        icon = LucideIcons.award;
+        gradient = LinearGradient(
+          begin: Alignment.topRight,
+          end: Alignment.bottomLeft,
+          colors: [colors.accentGradientStart, colors.accentGradientEnd],
+        );
         break;
       case "Recompensas":
-        icon = IconsaxBold.box;
+        icon = LucideIcons.gift;
+        gradient = LinearGradient(
+          begin: Alignment.topRight,
+          end: Alignment.bottomLeft,
+          colors: [colors.accentGradientStart, colors.accentGradientEnd],
+        );
         break;
       default:
-        icon = IconsaxBold.activity;
+        icon = LucideIcons.shieldCheck;
+        gradient = const LinearGradient(
+          begin: Alignment.topRight,
+          end: Alignment.bottomLeft,
+          colors: [
+            BondlyColors.badgeValoresStart,
+            BondlyColors.badgeValoresEnd,
+          ],
+        );
         break;
     }
 
-    var parsedDate = DateTime.parse(date).toString();
-    parsedDate = parsedDate
-        .replaceRange(parsedDate.length - 13, parsedDate.length, "")
-        .trim();
-
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-          margin: const EdgeInsets.only(top: 16.0, left: 12.0, right: 12.0),
-          width: double.infinity,
-          padding: const EdgeInsets.only(
-              top: 12.0, bottom: 12.0, left: 8.0, right: 16.0),
-          decoration: BoxDecoration(
-            color: theme.dividerColor,
-            borderRadius: const BorderRadius.all(Radius.circular(16.0)),
-            border: Border.all(color: theme.cardColor),
-          ),
-          child: Stack(
-            children: [
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Icon(
-                    icon,
-                    color: theme.unselectedWidgetColor,
-                    size: 36.0,
-                  ),
-                  const SizedBox(width: 8.0),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          title,
-                          style: theme.textTheme.headlineSmall!
-                              .copyWith(fontSize: 18.0),
-                        ),
-                        const SizedBox(height: 8.0),
-                        PostMentionsWidget(
-                          text: description,
-                          style: theme.textTheme.bodyMedium,
-                        ),
-                        const SizedBox(height: 24.0),
-                        Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 8.0, vertical: 4.0),
-                            decoration: BoxDecoration(
-                              color: theme.dividerColor,
-                              borderRadius: BorderRadius.circular(16.0),
-                            ),
-                            child: Text(parsedDate)),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(
-                    width: 24.0,
-                  )
-                ],
-              ),
-              !read
-                  ? Positioned(
-                      top: 0,
-                      right: 0,
-                      child: Icon(
-                        IconsaxBold.notification_status,
-                        color: colors.likeColor,
-                      ),
-                    )
-                  : Container()
-            ],
-          )),
+    return Container(
+      width: 32,
+      height: 32,
+      decoration: BoxDecoration(
+        gradient: gradient,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Icon(icon, size: 18, color: BondlyColors.white),
     );
+  }
+
+  Widget _buildDateRow(BondlyColorScheme colors) {
+    final parsedDate = _formatDate(date);
+
+    if (!read) {
+      return Row(
+        children: [
+          Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(
+              color: colors.accent,
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            parsedDate,
+            style: GoogleFonts.montserrat(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: colors.textMuted,
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Text(
+      parsedDate,
+      style: GoogleFonts.montserrat(
+        fontSize: 12,
+        fontWeight: FontWeight.w500,
+        color: colors.textMuted,
+      ),
+    );
+  }
+
+  String _formatDate(String dateStr) {
+    try {
+      final dt = DateTime.parse(dateStr);
+      final day = dt.day.toString().padLeft(2, '0');
+      final month = dt.month.toString().padLeft(2, '0');
+      return '$day/$month/${dt.year}';
+    } catch (_) {
+      return dateStr;
+    }
   }
 }

--- a/lib/features/profile/ui/widgets/user_activity_item.dart
+++ b/lib/features/profile/ui/widgets/user_activity_item.dart
@@ -46,7 +46,6 @@ class UserActivityItemWidget extends StatelessWidget {
       child: Container(
         decoration: BoxDecoration(
           color: colors.surface,
-          borderRadius: BorderRadius.circular(AppDimensions.radiusCard),
           border: Border.all(color: colors.accent, width: 1),
         ),
         child: IntrinsicHeight(

--- a/lib/ui/shared/feed_post_helpers.dart
+++ b/lib/ui/shared/feed_post_helpers.dart
@@ -1,0 +1,41 @@
+import 'package:bondly_app/config/strings_home.dart';
+import 'package:bondly_app/ui/shared/badge_icon_button.dart';
+import 'package:moment_dart/moment_dart.dart';
+
+class FeedPostHelpers {
+  FeedPostHelpers._();
+
+  static BadgeType resolveBadgeType(String type) {
+    final lower = type.toLowerCase();
+    if (lower.contains('especial')) return BadgeType.especiales;
+    if (lower.contains('valor') || lower.contains('embajada')) {
+      return BadgeType.valores;
+    }
+    return BadgeType.competencias;
+  }
+
+  static String resolveBadgeCategory(String type) {
+    final lower = type.toLowerCase();
+    if (lower.contains('especial')) return StringsHome.badgeEspeciales;
+    if (lower.contains('valor') || lower.contains('embajada')) {
+      return StringsHome.badgeValores;
+    }
+    return StringsHome.badgeCompetencias;
+  }
+
+  static String formatDate(DateTime date) {
+    final moment = Moment(date.toLocal());
+    return moment.format('DD MMM YYYY');
+  }
+
+  static String formatTimeAgo(String? timestamp) {
+    if (timestamp == null) return '';
+    try {
+      final date = DateTime.parse(timestamp);
+      final moment = Moment(date.toLocal());
+      return moment.fromNow(dropPrefixOrSuffix: true);
+    } catch (_) {
+      return '';
+    }
+  }
+}


### PR DESCRIPTION
 Summary                                                                                  

  - Redesigned the Mi Actividad screen with a new custom header, gradient info banner, and
  redesigned activity cards supporting read/unread visual variants
  - Redesigned the Activity Detail screen replacing the old SinglePostWidget +
  BondlySliverLayout with the shared FeedPostCard widget used in the feed tab, ensuring
  visual consistency across the app
  - Redesigned the UserActivityItemWidget with type-specific gradient icons, asymmetric
  accent border for unread cards, 70% opacity for read cards, and formatted date rows with
  unread dot indicator

  Changes

  my_activity_screen.dart
  - Replaced NestedScrollView + SliverAppBar with custom 56px header (circular back button,
   centered title)
  - Added accent gradient info banner with description bullets at the top of the list
  - Switched to BondlyColorScheme tokens and GoogleFonts.montserrat for consistent theming
  - Shimmer skeleton loading state for initial load
  - Notification toast overlay with new card styling
  - Kept pagination via ScrollEndNotification and AutomaticKeepAliveClientMixin

  activity_detail_screen.dart
  - Replaced SinglePostWidget with FeedPostCard (same widget used in tab_feed.dart)
  - Added full interaction support: likes, expandable comments, inline comment input
  - Reuses badge type resolution helpers (_resolveBadgeType, _resolveBadgeCategory)
  matching feed tab logic
  - New error state with alertCircle icon and themed card
  - Shimmer skeleton loading matching post card proportions

  user_activity_item.dart
  - Unread cards: surface bg, ClipRRect + IntrinsicHeight Row with 2px accent left bar, 1px
   accent border
  - Read cards: surfaceElevated bg, 70% opacity, uniform 1px border, no dot
  - Type icons: 32px gradient circles — award (Reconocimientos, accent gradient), gift
  (Recompensas, accent gradient), shieldCheck (default/Embajada, green→blue gradient)
  - Date formatted as DD/MM/YYYY with accent dot indicator for unread items
  - Migrated from ficonsax to lucide_icons

  Test plan

  - Open Mi Actividad from profile — verify gradient info banner renders correctly
  - Scroll to trigger pagination — verify shimmer loading indicator appears and new items
  load
  - Verify unread cards show left accent bar + dot indicator
  - Verify read cards show at 70% opacity with uniform border
  - Tap an unread card — verify it navigates to Activity Detail and marks as read
  - On Activity Detail, verify the FeedPostCard renders badge banner, user row, message,
  and actions bar
  - Tap like on Activity Detail — verify busy state and like toggle
  - Expand comments — verify comment bubbles and inline input appear
  - Verify light and dark theme on both screens