### PR TITLE
SPA deep-link routing + AI edge-function auth/CORS

### DIFF
--- a/lib/features/ai/data/api/gemini_service.dart
+++ b/lib/features/ai/data/api/gemini_service.dart
@@ -12,9 +12,18 @@ class GeminiService {
     try {
       _log.i('Gemini request initiated (via Edge Function)');
 
+      // Explicitly attach the session token. The Edge Function requires an
+      // Authorization header (verify_jwt=false + its own getUser check), and
+      // relying on the client's implicit header has proven flaky on web.
+      final session = Supabase.instance.client.auth.currentSession;
+      if (session == null) {
+        throw GeminiServiceException('No active session for Gemini request');
+      }
+
       final response = await Supabase.instance.client.functions.invoke(
         'gemini',
         body: {'prompt': prompt},
+        headers: {'Authorization': 'Bearer ${session.accessToken}'},
       );
 
       final dynamic data = response.data;

--- a/supabase/functions/_shared/presentation/http/response.ts
+++ b/supabase/functions/_shared/presentation/http/response.ts
@@ -5,16 +5,19 @@
 
 const ALLOWED_ORIGINS = [
   "https://bondly-app.vercel.app",
+  "https://bondly.fluss.mx",
 ];
 
 /**
  * Check if an origin is allowed for CORS.
- * Allows: production Vercel URL, Vercel preview deploys, and localhost for dev.
+ * Allows: production domains, Vercel preview deploys, any *.fluss.mx custom
+ * domain, and localhost for dev.
  */
 function isAllowedOrigin(origin: string | null): boolean {
   if (!origin) return false;
   if (ALLOWED_ORIGINS.includes(origin)) return true;
   if (/^https:\/\/bondly-app-.+\.vercel\.app$/.test(origin)) return true;
+  if (/^https:\/\/[a-z0-9-]+\.fluss\.mx$/.test(origin)) return true;
   if (/^http:\/\/localhost(:\d+)?$/.test(origin)) return true;
   return false;
 }

--- a/supabase/functions/gemini/index.ts
+++ b/supabase/functions/gemini/index.ts
@@ -2,13 +2,17 @@ import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { GoogleGenerativeAI } from "https://esm.sh/@google/generative-ai@0.21.0";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-const ALLOWED_ORIGINS = ["https://bondly-app.vercel.app"];
+const ALLOWED_ORIGINS = [
+  "https://bondly-app.vercel.app",
+  "https://bondly.fluss.mx",
+];
 
 function getCorsHeaders(origin: string | null): Record<string, string> {
   let allowed = ALLOWED_ORIGINS[0];
   if (origin) {
     if (ALLOWED_ORIGINS.includes(origin)
       || /^https:\/\/bondly-app-.+\.vercel\.app$/.test(origin)
+      || /^https:\/\/[a-z0-9-]+\.fluss\.mx$/.test(origin)
       || /^http:\/\/localhost(:\d+)?$/.test(origin)) {
       allowed = origin;
     }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "buildCommand": "echo \"SUPABASE_URL=$SUPABASE_URL\" > .env && echo \"SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY\" >> .env && echo \"GEMINI_API_KEY=$GEMINI_API_KEY\" >> .env && echo \"BACKEND=$BACKEND\" >> .env && flutter/bin/flutter build web --release",
   "outputDirectory": "build/web",
-  "installCommand": "if cd flutter; then git pull && cd ..; else git clone https://github.com/flutter/flutter.git -b stable --depth 1; fi && flutter/bin/flutter doctor && flutter/bin/flutter config --enable-web"
+  "installCommand": "if cd flutter; then git pull && cd ..; else git clone https://github.com/flutter/flutter.git -b stable --depth 1; fi && flutter/bin/flutter doctor && flutter/bin/flutter config --enable-web",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
 }


### PR DESCRIPTION
Two production fixes bundled (per request), on a fresh branch off main.

## 1. SPA deep-link 404s (Vercel)
The app uses path-based URLs (`usePathUrlStrategy`), so opening `/loginScreen` or any client route directly made Vercel 404 (no such file). Added a catch-all rewrite in `vercel.json` so every non-file path serves `index.html` and Flutter's router takes over — deep links load the app **and keep their URL**. Real static assets still resolve directly (Vercel only rewrites when no file matches).

## 2. AI "Missing Authorization header"
AI features (feed personalization, sentiment, reward recommendations) all failed. Two causes, both fixed:

- **CORS** — the `gemini` function and `_shared/presentation/http/response.ts` only allowed `bondly-app.vercel.app` + Vercel previews + localhost. Calls from the real domain (`bondly.fluss.mx`) were blocked by the browser. Added the production domain + a `*.fluss.mx` pattern to both. Since `_shared/response.ts` backs every other edge function (charts, reports), those are unblocked too.
- **Auth header** — `GeminiService` relied on the Supabase client attaching the session token implicitly to `functions.invoke` (flaky on web). Now it reads `currentSession` and passes `Authorization: Bearer <token>` explicitly, failing fast with a clear message if there's no session.

All 9 edge functions were redeployed with the CORS change.

## Verification
- `flutter analyze`: 0 errors
- Edge functions deployed to project `emyqillsdjtiqlnwdheq`.

## Note for the reviewer / follow-up
If AI still errors after this, check that `GEMINI_API_KEY` is set as a **Supabase secret** for the `gemini` function (the function throws "GEMINI_API_KEY is not set" → 500 if missing). That's separate from the client-side `.env` and from CORS/auth — this PR only fixes the auth/CORS path that produced the "Missing Authorization header" error.