### PR TITLE
Fix reward images in collaborator grid + cart

### DIFF
--- a/lib/features/profile/ui/screens/my_rewards_screen.dart
+++ b/lib/features/profile/ui/screens/my_rewards_screen.dart
@@ -600,7 +600,7 @@ class _MyRewardsScreenState extends State<MyRewardsScreen> {
                   child: AspectRatio(
                     aspectRatio: 16 / 10,
                     child: CachedNetworkImage(
-                      imageUrl: safeImageUrl(reward.imageUrl),
+                      imageUrl: safeImageUrl(reward.image),
                       fit: BoxFit.cover,
                       placeholder: (context, url) =>
                           const BondlyShimmerBlock(

--- a/lib/features/profile/ui/screens/shopping_cart_screen.dart
+++ b/lib/features/profile/ui/screens/shopping_cart_screen.dart
@@ -323,7 +323,7 @@ class CartItemTile extends StatelessWidget {
           borderRadius: BorderRadius.circular(AppDimensions.radiusSm),
           image: DecorationImage(
             image:
-                CachedNetworkImageProvider(safeImageUrl(item.reward.imageUrl)),
+                CachedNetworkImageProvider(safeImageUrl(item.reward.image)),
             fit: BoxFit.cover,
           ),
         ),


### PR DESCRIPTION
## Bug
In the collaborator rewards screen (`/myRewardsScreen`), every card showed the "Sin imagen" placeholder — but tapping a reward opened the full-screen image correctly. Same for cart thumbnails.

## Cause
`Reward.fromSupabase` populates two fields:
- `image` ← `json['image']` — the real Supabase storage URL ✅
- `imageUrl` ← `json['image_url']` — a column that **doesn't exist** on the `rewards` table, so it's always `null` ❌

The grid card (`my_rewards_screen.dart`) and cart thumbnail (`shopping_cart_screen.dart`) rendered `safeImageUrl(reward.imageUrl)`, which — given the null — returns the `placehold.co` "Sin imagen" image. The full-screen detail used `reward.image`, which is why it worked on tap.

## Fix
Point the grid and cart at `reward.image` (the populated field), matching the detail view. Two one-line changes. Rewards without an image still fall back to the placeholder via `safeImageUrl`'s empty-string handling.

## Verification
- `flutter analyze`: 0 errors
- `flutter build web`: succeeds