### PR TITLE
Voz: buzón de sugerencias (anónimo o no) + panel de triaje admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Supabase local dev state (never commit)
+supabase/.temp/
+supabase/.branches/
+models.json

--- a/lib/config/strings_admin.dart
+++ b/lib/config/strings_admin.dart
@@ -232,6 +232,20 @@ class StringsAdmin {
   static const String highlightFeed = 'Destacar';
   static const String unhighlightFeed = 'Quitar destacado';
 
+  // Voz — Buzón de sugerencias
+  static const String navSuggestions = 'Voz';
+  static const String suggestionsTitle = 'Buzón de Voz';
+  static const String suggestionsSubtitle =
+      'Sugerencias e inquietudes de los colaboradores';
+  static const String noSuggestionsFound = 'No hay sugerencias por ahora';
+  static const String suggestionDetail = 'Detalle de la sugerencia';
+  static const String suggestionStatus = 'Estado';
+  static const String suggestionAdminNote = 'Nota interna';
+  static const String suggestionAdminNoteHint =
+      'Uso interno del equipo (no se comparte con el autor)';
+  static const String suggestionCategory = 'Categoría';
+  static const String saveNote = 'Guardar nota';
+
   // Users: puntos y zonas
   static const String adjustPoints = 'Ajustar puntos';
   static const String pointsToGive = 'Puntos por regalar';

--- a/lib/config/strings_suggestions.dart
+++ b/lib/config/strings_suggestions.dart
@@ -1,0 +1,49 @@
+class StringsSuggestions {
+  StringsSuggestions._();
+
+  // Product identity — "Voz": tu voz dentro de Bondly
+  static const String voz = 'Voz';
+  static const String screenTitle = 'Tu Voz';
+  static const String screenSubtitle =
+      'Comparte ideas, sugerencias o inquietudes. Tú decides si con nombre o de forma anónima.';
+
+  // Form
+  static const String subjectLabel = 'Asunto (opcional)';
+  static const String subjectHint = 'Resume tu idea en pocas palabras';
+  static const String categoryLabel = 'Categoría';
+  static const String messageLabel = 'Tu mensaje';
+  static const String messageHint = 'Cuéntanos con detalle...';
+  static const String anonymousLabel = 'Enviar de forma anónima';
+  static const String anonymousHelp =
+      'Nadie podrá ver quién lo envió, ni siquiera los administradores.';
+  static const String send = 'Enviar';
+  static const String sending = 'Enviando...';
+  static const String sentSuccess = '¡Gracias! Tu voz fue enviada.';
+  static const String sendError = 'No se pudo enviar. Intenta de nuevo.';
+  static const String messageRequired = 'Escribe tu mensaje antes de enviar.';
+
+  // Categories
+  static const List<String> categories = [
+    'General',
+    'Ambiente laboral',
+    'Reconocimientos',
+    'Recompensas',
+    'Tecnología',
+    'Otro',
+  ];
+
+  // My suggestions
+  static const String mySuggestions = 'Mis envíos';
+  static const String noneYet = 'Aún no has enviado nada. ¡Tu voz cuenta!';
+  static const String anonymousTag = 'Anónimo';
+
+  // Status value → label (shared with admin; keys match suggestion_status enum)
+  static const Map<String, String> statusLabels = {
+    'nueva': 'Nueva',
+    'en_revision': 'En revisión',
+    'resuelta': 'Resuelta',
+    'archivada': 'Archivada',
+  };
+
+  static String statusLabel(String status) => statusLabels[status] ?? status;
+}

--- a/lib/dependencies/admin_repository_provider.dart
+++ b/lib/dependencies/admin_repository_provider.dart
@@ -8,6 +8,7 @@ import 'package:bondly_app/features/admin/data/repositories/supabase_admin_feeds
 import 'package:bondly_app/features/admin/data/repositories/supabase_admin_news_repository.dart';
 import 'package:bondly_app/features/admin/data/repositories/supabase_admin_permissions_repository.dart';
 import 'package:bondly_app/features/admin/data/repositories/supabase_admin_rewards_repository.dart';
+import 'package:bondly_app/features/admin/data/repositories/supabase_admin_suggestions_repository.dart';
 import 'package:bondly_app/features/admin/data/repositories/supabase_admin_users_repository.dart';
 import 'package:bondly_app/features/admin/data/repositories/supabase_admin_zones_repository.dart';
 import 'package:bondly_app/features/admin/domain/repositories/admin_auth_repository.dart';
@@ -47,6 +48,9 @@ class AdminRepositoryProvider {
     );
     getIt.registerSingleton<SupabaseAdminFeedsRepository>(
       SupabaseAdminFeedsRepository(getIt<SupabaseClientProvider>()),
+    );
+    getIt.registerSingleton<SupabaseAdminSuggestionsRepository>(
+      SupabaseAdminSuggestionsRepository(getIt<SupabaseClientProvider>()),
     );
   }
 }

--- a/lib/dependencies/admin_viewmodel_provider.dart
+++ b/lib/dependencies/admin_viewmodel_provider.dart
@@ -7,6 +7,7 @@ import 'package:bondly_app/features/admin/data/repositories/supabase_admin_feeds
 import 'package:bondly_app/features/admin/data/repositories/supabase_admin_news_repository.dart';
 import 'package:bondly_app/features/admin/data/repositories/supabase_admin_permissions_repository.dart';
 import 'package:bondly_app/features/admin/data/repositories/supabase_admin_rewards_repository.dart';
+import 'package:bondly_app/features/admin/data/repositories/supabase_admin_suggestions_repository.dart';
 import 'package:bondly_app/features/admin/data/repositories/supabase_admin_users_repository.dart';
 import 'package:bondly_app/features/admin/data/repositories/supabase_admin_zones_repository.dart';
 import 'package:bondly_app/features/admin/domain/usecases/get_admin_permissions_usecase.dart';
@@ -22,6 +23,7 @@ import 'package:bondly_app/features/admin/ui/viewmodels/admin_permissions_viewmo
 import 'package:bondly_app/features/admin/ui/viewmodels/admin_reports_viewmodel.dart';
 import 'package:bondly_app/features/admin/ui/viewmodels/admin_rewards_viewmodel.dart';
 import 'package:bondly_app/features/admin/ui/viewmodels/admin_shell_viewmodel.dart';
+import 'package:bondly_app/features/admin/ui/viewmodels/admin_suggestions_viewmodel.dart';
 import 'package:bondly_app/features/admin/ui/viewmodels/admin_users_viewmodel.dart';
 import 'package:bondly_app/features/admin/ui/viewmodels/admin_zones_viewmodel.dart';
 import 'package:bondly_app/features/auth/domain/usecases/user_usecase.dart';
@@ -82,6 +84,10 @@ class AdminViewModelProvider {
     );
     getIt.registerFactory<AdminFeedsViewModel>(
       () => AdminFeedsViewModel(getIt<SupabaseAdminFeedsRepository>()),
+    );
+    getIt.registerFactory<AdminSuggestionsViewModel>(
+      () => AdminSuggestionsViewModel(
+          getIt<SupabaseAdminSuggestionsRepository>()),
     );
   }
 }

--- a/lib/dependencies/repository_provider.dart
+++ b/lib/dependencies/repository_provider.dart
@@ -16,6 +16,8 @@ import 'package:bondly_app/features/profile/data/repositories/supabase_bondly_ba
 import 'package:bondly_app/features/profile/data/repositories/supabase_cart_repository.dart';
 import 'package:bondly_app/features/ranking/data/repositories/supabase_ranking_repository.dart';
 import 'package:bondly_app/features/ranking/domain/repositories/ranking_repository.dart';
+import 'package:bondly_app/features/suggestions/data/repositories/supabase_suggestions_repository.dart';
+import 'package:bondly_app/features/suggestions/domain/repositories/suggestions_repository.dart';
 import 'package:bondly_app/src/supabase_client_provider.dart';
 import 'package:bondly_app/features/auth/data/repositories/api/auth_api.dart';
 import 'package:bondly_app/features/auth/data/repositories/api/users_api.dart';
@@ -166,6 +168,10 @@ class RepositoryProvider {
 
     getIt.registerSingleton<RankingRepository>(
       SupabaseRankingRepository(getIt<SupabaseClientProvider>()),
+    );
+
+    getIt.registerSingleton<SuggestionsRepository>(
+      SupabaseSuggestionsRepository(getIt<SupabaseClientProvider>()),
     );
 
     getIt.registerSingleton<AIRepository>(

--- a/lib/dependencies/usecase_provider.dart
+++ b/lib/dependencies/usecase_provider.dart
@@ -29,6 +29,9 @@ import 'package:bondly_app/features/profile/domain/repositories/bondly_badges_re
 import 'package:bondly_app/features/profile/domain/repositories/cart_repository.dart';
 import 'package:bondly_app/features/ranking/domain/repositories/ranking_repository.dart';
 import 'package:bondly_app/features/ranking/domain/usecases/get_ranking_usecase.dart';
+import 'package:bondly_app/features/suggestions/domain/repositories/suggestions_repository.dart';
+import 'package:bondly_app/features/suggestions/domain/usecases/get_my_suggestions_usecase.dart';
+import 'package:bondly_app/features/suggestions/domain/usecases/submit_suggestion_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/bulk_add_cart_items_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/checkout_cart_usecase.dart';
 import 'package:bondly_app/features/profile/domain/usecases/clear_shopping_cart_usecase.dart';
@@ -200,6 +203,12 @@ class UseCaseProvider {
 
     getIt.registerSingleton<GetRankingUseCase>(
         GetRankingUseCase(getIt<RankingRepository>()));
+
+    getIt.registerSingleton<SubmitSuggestionUseCase>(
+        SubmitSuggestionUseCase(getIt<SuggestionsRepository>()));
+
+    getIt.registerSingleton<GetMySuggestionsUseCase>(
+        GetMySuggestionsUseCase(getIt<SuggestionsRepository>()));
 
     getIt.registerSingletonWithDependencies<UserProfileUseCase>(
         () => UserProfileUseCase(

--- a/lib/dependencies/viewmodel_provider.dart
+++ b/lib/dependencies/viewmodel_provider.dart
@@ -48,6 +48,9 @@ import 'package:bondly_app/features/profile/ui/viewmodels/my_rewards_viewmodel.d
 import 'package:bondly_app/features/profile/ui/viewmodels/profile_viewmodel.dart';
 import 'package:bondly_app/features/ranking/domain/usecases/get_ranking_usecase.dart';
 import 'package:bondly_app/features/ranking/ui/viewmodels/ranking_viewmodel.dart';
+import 'package:bondly_app/features/suggestions/domain/usecases/get_my_suggestions_usecase.dart';
+import 'package:bondly_app/features/suggestions/domain/usecases/submit_suggestion_usecase.dart';
+import 'package:bondly_app/features/suggestions/ui/viewmodels/suggestions_viewmodel.dart';
 import 'package:bondly_app/src/app_services.dart';
 import 'package:bondly_app/src/routes.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -150,5 +153,11 @@ class ViewModelProvider {
 
     getIt.registerFactory<RankingViewModel>(
         () => RankingViewModel(getIt<GetRankingUseCase>()));
+
+    getIt.registerFactory<SuggestionsViewModel>(
+        () => SuggestionsViewModel(
+              getIt<SubmitSuggestionUseCase>(),
+              getIt<GetMySuggestionsUseCase>(),
+            ));
   }
 }

--- a/lib/features/admin/data/repositories/supabase_admin_suggestions_repository.dart
+++ b/lib/features/admin/data/repositories/supabase_admin_suggestions_repository.dart
@@ -1,0 +1,64 @@
+import 'package:bondly_app/features/admin/domain/models/admin_suggestion.dart';
+import 'package:bondly_app/src/supabase_client_provider.dart';
+import 'package:multiple_result/multiple_result.dart';
+
+class SupabaseAdminSuggestionsRepository {
+  final SupabaseClientProvider _supabase;
+
+  SupabaseAdminSuggestionsRepository(this._supabase);
+
+  /// Suggestions with the author joined. Anonymous rows have no author.
+  /// [status] optionally filters by lifecycle stage.
+  Future<Result<List<AdminSuggestion>, Exception>> getSuggestions({
+    String? status,
+  }) async {
+    try {
+      var query = _supabase.client
+          .from('suggestions')
+          .select('*, author:users(complete_name)')
+          .eq('visible', true);
+      if (status != null) query = query.eq('status', status);
+      final response = await query
+          .order('created_at', ascending: false)
+          // ponytail: newest-100 cap like exchanges; add range() paging if it fills
+          .limit(100);
+      final items = (response as List)
+          .map((e) => AdminSuggestion.fromJson(e as Map<String, dynamic>))
+          .toList();
+      return Result.success(items);
+    } catch (e) {
+      return Result.error(Exception(e.toString()));
+    }
+  }
+
+  Future<Result<void, Exception>> updateStatus(String id, String status) async {
+    try {
+      await _supabase.client
+          .from('suggestions')
+          .update({'status': status}).eq('id', id);
+      return const Result.success(null);
+    } catch (e) {
+      return Result.error(Exception(e.toString()));
+    }
+  }
+
+  Future<Result<void, Exception>> updateNote(String id, String? note) async {
+    try {
+      await _supabase.client
+          .from('suggestions')
+          .update({'admin_note': note}).eq('id', id);
+      return const Result.success(null);
+    } catch (e) {
+      return Result.error(Exception(e.toString()));
+    }
+  }
+
+  Future<Result<void, Exception>> delete(String id) async {
+    try {
+      await _supabase.client.from('suggestions').delete().eq('id', id);
+      return const Result.success(null);
+    } catch (e) {
+      return Result.error(Exception(e.toString()));
+    }
+  }
+}

--- a/lib/features/admin/domain/models/admin_module.dart
+++ b/lib/features/admin/domain/models/admin_module.dart
@@ -7,7 +7,8 @@ enum AdminModule {
   viewReports('view_reports'),
   manageZones('manage_zones'),
   manageSettings('manage_settings'),
-  manageFeeds('manage_feeds');
+  manageFeeds('manage_feeds'),
+  manageSuggestions('manage_suggestions');
 
   final String value;
   const AdminModule(this.value);

--- a/lib/features/admin/domain/models/admin_suggestion.dart
+++ b/lib/features/admin/domain/models/admin_suggestion.dart
@@ -1,0 +1,40 @@
+class AdminSuggestion {
+  final String id;
+  final String? title;
+  final String? category;
+  final String message;
+  final String status;
+  final bool isAnonymous;
+  final String? adminNote;
+  final DateTime? createdAt;
+  final String? authorName;
+
+  const AdminSuggestion({
+    required this.id,
+    this.title,
+    this.category,
+    required this.message,
+    required this.status,
+    required this.isAnonymous,
+    this.adminNote,
+    this.createdAt,
+    this.authorName,
+  });
+
+  factory AdminSuggestion.fromJson(Map<String, dynamic> json) {
+    final author = json['author'] as Map<String, dynamic>?;
+    return AdminSuggestion(
+      id: json['id'] as String,
+      title: json['title'] as String?,
+      category: json['category'] as String?,
+      message: json['message'] as String? ?? '',
+      status: json['status'] as String? ?? 'nueva',
+      isAnonymous: json['is_anonymous'] as bool? ?? false,
+      adminNote: json['admin_note'] as String?,
+      createdAt: json['created_at'] != null
+          ? DateTime.tryParse(json['created_at'] as String)
+          : null,
+      authorName: author?['complete_name'] as String?,
+    );
+  }
+}

--- a/lib/features/admin/ui/screens/admin_permissions_screen.dart
+++ b/lib/features/admin/ui/screens/admin_permissions_screen.dart
@@ -302,5 +302,6 @@ class _PermissionsGrid extends StatelessWidget {
         AdminModule.manageZones => StringsAdmin.navZones,
         AdminModule.manageSettings => StringsAdmin.navSettings,
         AdminModule.manageFeeds => StringsAdmin.navFeeds,
+        AdminModule.manageSuggestions => StringsAdmin.navSuggestions,
       };
 }

--- a/lib/features/admin/ui/screens/admin_suggestions_screen.dart
+++ b/lib/features/admin/ui/screens/admin_suggestions_screen.dart
@@ -1,0 +1,303 @@
+import 'package:bondly_app/config/colors.dart';
+import 'package:bondly_app/config/strings_admin.dart';
+import 'package:bondly_app/config/strings_suggestions.dart';
+import 'package:bondly_app/dependencies/dependency_manager.dart';
+import 'package:bondly_app/features/admin/domain/models/admin_module.dart';
+import 'package:bondly_app/features/admin/domain/models/admin_suggestion.dart';
+import 'package:bondly_app/features/admin/ui/viewmodels/admin_suggestions_viewmodel.dart';
+import 'package:bondly_app/features/admin/ui/widgets/admin_empty_state.dart';
+import 'package:bondly_app/features/admin/ui/widgets/admin_permission_guard.dart';
+import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
+import 'package:bondly_app/features/suggestions/ui/widgets/suggestion_status_chip.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:intl/intl.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+class AdminSuggestionsScreen extends StatefulWidget {
+  static const String route = '/admin/suggestions';
+
+  const AdminSuggestionsScreen({super.key});
+
+  @override
+  State<AdminSuggestionsScreen> createState() => _AdminSuggestionsScreenState();
+}
+
+class _AdminSuggestionsScreenState extends State<AdminSuggestionsScreen> {
+  late AdminSuggestionsViewModel _vm;
+
+  @override
+  void initState() {
+    super.initState();
+    _vm = getIt<AdminSuggestionsViewModel>();
+    _vm.load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<BondlyColorScheme>()!;
+
+    return AdminPermissionGuard(
+      module: AdminModule.manageSuggestions,
+      child: ModelProvider<AdminSuggestionsViewModel>(
+        model: _vm,
+        child: ModelBuilder<AdminSuggestionsViewModel>(
+          builder: (context, vm, _) => Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  StringsAdmin.suggestionsTitle,
+                  style: GoogleFonts.montserrat(
+                    fontSize: 22,
+                    fontWeight: FontWeight.bold,
+                    color: colors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  StringsAdmin.suggestionsSubtitle,
+                  style: GoogleFonts.montserrat(
+                      fontSize: 13, color: colors.textMuted),
+                ),
+                const SizedBox(height: 16),
+                _buildFilters(vm, colors),
+                const SizedBox(height: 12),
+                Expanded(
+                  child: vm.isLoading
+                      ? const Center(child: CircularProgressIndicator())
+                      : vm.error != null
+                          ? AdminEmptyState(
+                              icon: LucideIcons.alertCircle,
+                              message: vm.error!,
+                              ctaLabel: StringsAdmin.retry,
+                              onCta: vm.load)
+                          : vm.items.isEmpty
+                              ? const AdminEmptyState(
+                                  icon: LucideIcons.messageCircle,
+                                  message: StringsAdmin.noSuggestionsFound,
+                                )
+                              : _SuggestionsList(vm: vm, colors: colors),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFilters(
+      AdminSuggestionsViewModel vm, BondlyColorScheme colors) {
+    Widget chip(String? value, String label) {
+      final selected = vm.statusFilter == value;
+      return Padding(
+        padding: const EdgeInsets.only(right: 8),
+        child: ChoiceChip(
+          label: Text(label),
+          selected: selected,
+          onSelected: (_) => vm.setStatusFilter(value),
+        ),
+      );
+    }
+
+    return Wrap(
+      children: [
+        chip(null, StringsAdmin.all),
+        ...StringsSuggestions.statusLabels.entries
+            .map((e) => chip(e.key, e.value)),
+      ],
+    );
+  }
+}
+
+class _SuggestionsList extends StatelessWidget {
+  final AdminSuggestionsViewModel vm;
+  final BondlyColorScheme colors;
+
+  const _SuggestionsList({required this.vm, required this.colors});
+
+  String _authorOf(AdminSuggestion s) =>
+      (!s.isAnonymous && s.authorName?.isNotEmpty == true)
+          ? s.authorName!
+          : StringsSuggestions.anonymousTag;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      itemCount: vm.items.length,
+      separatorBuilder: (_, __) => Divider(height: 1, color: colors.border),
+      itemBuilder: (ctx, i) {
+        final s = vm.items[i];
+        return ListTile(
+          leading: CircleAvatar(
+            backgroundColor: colors.surfaceElevated,
+            child: Icon(
+              s.isAnonymous ? LucideIcons.userX : LucideIcons.user,
+              size: 18,
+              color: colors.textMuted,
+            ),
+          ),
+          title: Text(
+            s.title?.isNotEmpty == true ? s.title! : s.message,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: GoogleFonts.montserrat(
+                fontSize: 14, fontWeight: FontWeight.w600),
+          ),
+          subtitle: Text(
+            [
+              _authorOf(s),
+              if (s.category != null) s.category!,
+              if (s.createdAt != null)
+                DateFormat('dd MMM', 'es').format(s.createdAt!),
+            ].join(' · '),
+            style: GoogleFonts.montserrat(
+                fontSize: 12, color: colors.textMuted),
+          ),
+          trailing: SuggestionStatusChip(status: s.status),
+          onTap: () => _showDetail(ctx, s),
+        );
+      },
+    );
+  }
+
+  void _showDetail(BuildContext context, AdminSuggestion s) {
+    final noteCtrl = TextEditingController(text: s.adminNote);
+    final author = _authorOf(s);
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: colors.surface,
+        title: Text(
+          StringsAdmin.suggestionDetail,
+          style: GoogleFonts.montserrat(fontWeight: FontWeight.bold),
+        ),
+        content: SizedBox(
+          width: (MediaQuery.of(context).size.width - 32).clamp(0.0, 520.0),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    Icon(s.isAnonymous ? LucideIcons.userX : LucideIcons.user,
+                        size: 16, color: colors.textMuted),
+                    const SizedBox(width: 6),
+                    Text(author,
+                        style: GoogleFonts.montserrat(
+                            fontSize: 13, fontWeight: FontWeight.w600)),
+                    const Spacer(),
+                    if (s.createdAt != null)
+                      Text(
+                        DateFormat('dd MMM yyyy', 'es').format(s.createdAt!),
+                        style: GoogleFonts.montserrat(
+                            fontSize: 12, color: colors.textMuted),
+                      ),
+                  ],
+                ),
+                if (s.category != null) ...[
+                  const SizedBox(height: 8),
+                  Text('${StringsAdmin.suggestionCategory}: ${s.category}',
+                      style: GoogleFonts.montserrat(
+                          fontSize: 12, color: colors.textSecondary)),
+                ],
+                if (s.title?.isNotEmpty == true) ...[
+                  const SizedBox(height: 12),
+                  Text(s.title!,
+                      style: GoogleFonts.montserrat(
+                          fontSize: 15, fontWeight: FontWeight.w700)),
+                ],
+                const SizedBox(height: 8),
+                Text(s.message,
+                    style: GoogleFonts.montserrat(
+                        fontSize: 14, height: 1.4)),
+                const SizedBox(height: 16),
+                Text(StringsAdmin.suggestionStatus,
+                    style: GoogleFonts.montserrat(
+                        fontSize: 12, fontWeight: FontWeight.w600)),
+                const SizedBox(height: 6),
+                Wrap(
+                  spacing: 8,
+                  children: StringsSuggestions.statusLabels.entries.map((e) {
+                    final selected = s.status == e.key;
+                    return ChoiceChip(
+                      label: Text(e.value),
+                      selected: selected,
+                      onSelected: (_) {
+                        vm.updateStatus(s, e.key);
+                        Navigator.pop(ctx);
+                      },
+                    );
+                  }).toList(),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: noteCtrl,
+                  maxLines: 3,
+                  decoration: InputDecoration(
+                    labelText: StringsAdmin.suggestionAdminNote,
+                    hintText: StringsAdmin.suggestionAdminNoteHint,
+                    border: const OutlineInputBorder(),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            onPressed: () {
+              Navigator.pop(ctx);
+              _confirmDelete(context, s);
+            },
+            child: const Text(StringsAdmin.delete),
+          ),
+          TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text(StringsAdmin.cancel)),
+          FilledButton(
+            onPressed: () {
+              vm.updateNote(
+                  s, noteCtrl.text.trim().isEmpty ? null : noteCtrl.text.trim());
+              Navigator.pop(ctx);
+            },
+            child: const Text(StringsAdmin.saveNote),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmDelete(BuildContext context, AdminSuggestion s) {
+    showDialog(
+      context: context,
+      // Pop with the dialog's own ctx: this screen lives inside the admin
+      // ShellRoute navigator, but showDialog pushes onto the root navigator.
+      builder: (ctx) => AlertDialog(
+        backgroundColor: colors.surface,
+        title: Text(StringsAdmin.confirmDeleteTitle,
+            style: GoogleFonts.montserrat(fontWeight: FontWeight.bold)),
+        content: Text(StringsAdmin.confirmDeleteMessage,
+            style: GoogleFonts.montserrat()),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text(StringsAdmin.cancel)),
+          FilledButton(
+            style: FilledButton.styleFrom(backgroundColor: Colors.red),
+            onPressed: () {
+              Navigator.pop(ctx);
+              vm.delete(s.id);
+            },
+            child: const Text(StringsAdmin.delete),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/admin/ui/viewmodels/admin_suggestions_viewmodel.dart
+++ b/lib/features/admin/ui/viewmodels/admin_suggestions_viewmodel.dart
@@ -1,0 +1,60 @@
+import 'package:bondly_app/features/admin/data/repositories/supabase_admin_suggestions_repository.dart';
+import 'package:bondly_app/features/admin/domain/models/admin_suggestion.dart';
+import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
+
+class AdminSuggestionsViewModel extends NavigationModel {
+  final SupabaseAdminSuggestionsRepository _repo;
+
+  List<AdminSuggestion> _items = [];
+  bool _isLoading = false;
+  String? _error;
+  String? _statusFilter;
+
+  AdminSuggestionsViewModel(this._repo);
+
+  List<AdminSuggestion> get items => _items;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+  String? get statusFilter => _statusFilter;
+
+  Future<void> load() async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    final r = await _repo.getSuggestions(status: _statusFilter);
+    r.when((data) => _items = data, (e) => _error = e.toString());
+
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  Future<void> setStatusFilter(String? status) async {
+    _statusFilter = status;
+    await load();
+  }
+
+  Future<void> updateStatus(AdminSuggestion item, String status) async {
+    final r = await _repo.updateStatus(item.id, status);
+    r.when((_) => load(), (e) {
+      _error = e.toString();
+      notifyListeners();
+    });
+  }
+
+  Future<void> updateNote(AdminSuggestion item, String? note) async {
+    final r = await _repo.updateNote(item.id, note);
+    r.when((_) => load(), (e) {
+      _error = e.toString();
+      notifyListeners();
+    });
+  }
+
+  Future<void> delete(String id) async {
+    final r = await _repo.delete(id);
+    r.when((_) => load(), (e) {
+      _error = e.toString();
+      notifyListeners();
+    });
+  }
+}

--- a/lib/features/admin/ui/widgets/admin_sidebar.dart
+++ b/lib/features/admin/ui/widgets/admin_sidebar.dart
@@ -78,6 +78,12 @@ const _navItems = [
     module: AdminModule.manageFeeds,
   ),
   _NavItem(
+    label: StringsAdmin.navSuggestions,
+    icon: LucideIcons.messageCircle,
+    route: '/admin/suggestions',
+    module: AdminModule.manageSuggestions,
+  ),
+  _NavItem(
     label: StringsAdmin.navReports,
     icon: LucideIcons.barChart2,
     route: '/admin/reports',

--- a/lib/features/profile/ui/screens/profile_screen.dart
+++ b/lib/features/profile/ui/screens/profile_screen.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 import 'package:bondly_app/config/colors.dart';
 import 'package:bondly_app/config/dimensions.dart';
 import 'package:bondly_app/config/strings_profile.dart';
+import 'package:bondly_app/config/strings_suggestions.dart';
+import 'package:bondly_app/features/suggestions/ui/screens/suggestions_screen.dart';
 import 'package:bondly_app/dependencies/dependency_manager.dart';
 import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
 import 'package:bondly_app/features/home/ui/widgets/full_screen_image.dart';
@@ -418,6 +420,11 @@ class ProfileScreenState extends State<ProfileScreen> {
         title: StringsProfile.monthlyReport,
         icon: LucideIcons.wallet,
         onTap: () => context.push(MonthlyBalanceScreen.route),
+      ),
+      _MenuItem(
+        title: StringsSuggestions.screenTitle,
+        icon: LucideIcons.messageCircle,
+        onTap: () => context.push(SuggestionsScreen.route),
       ),
     ];
 

--- a/lib/features/suggestions/data/repositories/supabase_suggestions_repository.dart
+++ b/lib/features/suggestions/data/repositories/supabase_suggestions_repository.dart
@@ -1,0 +1,48 @@
+import 'package:bondly_app/features/suggestions/domain/models/suggestion.dart';
+import 'package:bondly_app/features/suggestions/domain/repositories/suggestions_repository.dart';
+import 'package:bondly_app/src/supabase_client_provider.dart';
+import 'package:multiple_result/multiple_result.dart';
+
+class SupabaseSuggestionsRepository extends SuggestionsRepository {
+  final SupabaseClientProvider _provider;
+
+  SupabaseSuggestionsRepository(this._provider);
+
+  @override
+  Future<Result<void, Exception>> submit({
+    required String message,
+    String? title,
+    String? category,
+    required bool anonymous,
+  }) async {
+    try {
+      final userId = _provider.client.auth.currentUser?.id;
+      await _provider.client.from('suggestions').insert({
+        // Anonymous rows must not carry an author id (enforced by RLS too).
+        'user_id': anonymous ? null : userId,
+        'is_anonymous': anonymous,
+        'title': title,
+        'category': category,
+        'message': message,
+      });
+      return const Result.success(null);
+    } catch (e) {
+      return Result.error(SuggestionException(e.toString()));
+    }
+  }
+
+  @override
+  Future<Result<List<Suggestion>, Exception>> getMine() async {
+    try {
+      // RPC (SECURITY DEFINER): returns only the caller's own non-anonymous
+      // suggestions, without the internal admin_note field.
+      final response = await _provider.client.rpc('get_my_suggestions');
+      final items = (response as List)
+          .map((e) => Suggestion.fromSupabase(e as Map<String, dynamic>))
+          .toList();
+      return Result.success(items);
+    } catch (e) {
+      return Result.error(SuggestionException(e.toString()));
+    }
+  }
+}

--- a/lib/features/suggestions/domain/models/suggestion.dart
+++ b/lib/features/suggestions/domain/models/suggestion.dart
@@ -1,0 +1,33 @@
+class Suggestion {
+  final String id;
+  final String? title;
+  final String? category;
+  final String message;
+  final String status;
+  final bool isAnonymous;
+  final DateTime? createdAt;
+
+  const Suggestion({
+    required this.id,
+    this.title,
+    this.category,
+    required this.message,
+    required this.status,
+    required this.isAnonymous,
+    this.createdAt,
+  });
+
+  factory Suggestion.fromSupabase(Map<String, dynamic> json) {
+    return Suggestion(
+      id: json['id'] as String,
+      title: json['title'] as String?,
+      category: json['category'] as String?,
+      message: json['message'] as String? ?? '',
+      status: json['status'] as String? ?? 'nueva',
+      isAnonymous: json['is_anonymous'] as bool? ?? false,
+      createdAt: json['created_at'] != null
+          ? DateTime.tryParse(json['created_at'] as String)
+          : null,
+    );
+  }
+}

--- a/lib/features/suggestions/domain/repositories/suggestions_repository.dart
+++ b/lib/features/suggestions/domain/repositories/suggestions_repository.dart
@@ -1,0 +1,23 @@
+import 'package:bondly_app/features/suggestions/domain/models/suggestion.dart';
+import 'package:multiple_result/multiple_result.dart';
+
+abstract class SuggestionsRepository {
+  /// Submits a new suggestion. When [anonymous] is true no author is stored.
+  Future<Result<void, Exception>> submit({
+    required String message,
+    String? title,
+    String? category,
+    required bool anonymous,
+  });
+
+  /// The current user's own (non-anonymous) suggestions.
+  Future<Result<List<Suggestion>, Exception>> getMine();
+}
+
+class SuggestionException implements Exception {
+  final String message;
+  SuggestionException([this.message = 'Error con la sugerencia']);
+
+  @override
+  String toString() => message;
+}

--- a/lib/features/suggestions/domain/usecases/get_my_suggestions_usecase.dart
+++ b/lib/features/suggestions/domain/usecases/get_my_suggestions_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:bondly_app/features/suggestions/domain/models/suggestion.dart';
+import 'package:bondly_app/features/suggestions/domain/repositories/suggestions_repository.dart';
+import 'package:multiple_result/multiple_result.dart';
+
+class GetMySuggestionsUseCase {
+  final SuggestionsRepository repository;
+
+  GetMySuggestionsUseCase(this.repository);
+
+  Future<Result<List<Suggestion>, Exception>> invoke() async {
+    return repository.getMine();
+  }
+}

--- a/lib/features/suggestions/domain/usecases/submit_suggestion_usecase.dart
+++ b/lib/features/suggestions/domain/usecases/submit_suggestion_usecase.dart
@@ -1,0 +1,22 @@
+import 'package:bondly_app/features/suggestions/domain/repositories/suggestions_repository.dart';
+import 'package:multiple_result/multiple_result.dart';
+
+class SubmitSuggestionUseCase {
+  final SuggestionsRepository repository;
+
+  SubmitSuggestionUseCase(this.repository);
+
+  Future<Result<void, Exception>> invoke({
+    required String message,
+    String? title,
+    String? category,
+    required bool anonymous,
+  }) async {
+    return repository.submit(
+      message: message,
+      title: title,
+      category: category,
+      anonymous: anonymous,
+    );
+  }
+}

--- a/lib/features/suggestions/ui/screens/suggestions_screen.dart
+++ b/lib/features/suggestions/ui/screens/suggestions_screen.dart
@@ -1,0 +1,337 @@
+import 'package:bondly_app/config/colors.dart';
+import 'package:bondly_app/config/dimensions.dart';
+import 'package:bondly_app/config/strings_suggestions.dart';
+import 'package:bondly_app/dependencies/dependency_manager.dart';
+import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
+import 'package:bondly_app/features/suggestions/domain/models/suggestion.dart';
+import 'package:bondly_app/features/suggestions/ui/viewmodels/suggestions_viewmodel.dart';
+import 'package:bondly_app/features/suggestions/ui/widgets/suggestion_status_chip.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:intl/intl.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+class SuggestionsScreen extends StatefulWidget {
+  static const String route = '/suggestionsScreen';
+
+  const SuggestionsScreen({super.key});
+
+  @override
+  State<SuggestionsScreen> createState() => _SuggestionsScreenState();
+}
+
+class _SuggestionsScreenState extends State<SuggestionsScreen> {
+  late final SuggestionsViewModel _viewModel;
+  final _titleCtrl = TextEditingController();
+  final _messageCtrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _viewModel = getIt<SuggestionsViewModel>();
+    _viewModel.setUp();
+  }
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _messageCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onSend(SuggestionsViewModel model) async {
+    final message = _messageCtrl.text.trim();
+    if (message.isEmpty) {
+      _snack(StringsSuggestions.messageRequired);
+      return;
+    }
+    final ok = await model.submit(
+      message: message,
+      title: _titleCtrl.text.trim().isEmpty ? null : _titleCtrl.text.trim(),
+    );
+    if (!mounted) return;
+    if (ok) {
+      _titleCtrl.clear();
+      _messageCtrl.clear();
+      _snack(StringsSuggestions.sentSuccess);
+    } else {
+      _snack(StringsSuggestions.sendError);
+    }
+  }
+
+  void _snack(String message) {
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ModelProvider<SuggestionsViewModel>(
+      model: _viewModel,
+      child: ModelBuilder<SuggestionsViewModel>(
+        builder: (context, model, child) {
+          final colors = Theme.of(context).extension<BondlyColorScheme>()!;
+          return Scaffold(
+            backgroundColor: colors.bg,
+            body: SafeArea(
+              child: Column(
+                children: [
+                  _buildHeader(colors),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.fromLTRB(
+                        AppDimensions.paddingScreen,
+                        8,
+                        AppDimensions.paddingScreen,
+                        AppDimensions.paddingScreen,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            StringsSuggestions.screenSubtitle,
+                            style: GoogleFonts.montserrat(
+                              fontSize: 13,
+                              color: colors.textSecondary,
+                              height: 1.4,
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          _buildForm(colors, model),
+                          const SizedBox(height: 28),
+                          _buildMineSection(colors, model),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildHeader(BondlyColorScheme colors) {
+    return SizedBox(
+      height: 56,
+      child: Padding(
+        padding:
+            const EdgeInsets.symmetric(horizontal: AppDimensions.paddingScreen),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            GestureDetector(
+              onTap: () => context.pop(),
+              child: Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: colors.surfaceElevated,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(LucideIcons.arrowLeft,
+                    size: 18, color: colors.textPrimary),
+              ),
+            ),
+            Text(
+              StringsSuggestions.screenTitle,
+              style: GoogleFonts.montserrat(
+                fontSize: 18,
+                fontWeight: FontWeight.w700,
+                color: colors.textPrimary,
+              ),
+            ),
+            const SizedBox(width: 36),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildForm(BondlyColorScheme colors, SuggestionsViewModel model) {
+    return Container(
+      padding: const EdgeInsets.all(AppDimensions.paddingCard),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(AppDimensions.radiusCard),
+        border: Border.all(color: colors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: _titleCtrl,
+            decoration: InputDecoration(
+              labelText: StringsSuggestions.subjectLabel,
+              hintText: StringsSuggestions.subjectHint,
+              border: const OutlineInputBorder(),
+              isDense: true,
+            ),
+          ),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<String>(
+            // `value` stays synced with the model on rebuild (so it resets after
+            // submit); `initialValue` would not.
+            // ignore: deprecated_member_use
+            value: model.category,
+            isExpanded: true,
+            decoration: InputDecoration(
+              labelText: StringsSuggestions.categoryLabel,
+              border: const OutlineInputBorder(),
+              isDense: true,
+            ),
+            items: StringsSuggestions.categories
+                .map((c) => DropdownMenuItem(value: c, child: Text(c)))
+                .toList(),
+            onChanged: (v) => model.category = v,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _messageCtrl,
+            maxLines: 5,
+            decoration: InputDecoration(
+              labelText: StringsSuggestions.messageLabel,
+              hintText: StringsSuggestions.messageHint,
+              border: const OutlineInputBorder(),
+              alignLabelWithHint: true,
+            ),
+          ),
+          const SizedBox(height: 8),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            value: model.anonymous,
+            onChanged: (v) => model.anonymous = v,
+            activeThumbColor: colors.accent,
+            title: Text(
+              StringsSuggestions.anonymousLabel,
+              style: GoogleFonts.montserrat(
+                  fontSize: 14, fontWeight: FontWeight.w600),
+            ),
+            subtitle: Text(
+              StringsSuggestions.anonymousHelp,
+              style: GoogleFonts.montserrat(
+                  fontSize: 12, color: colors.textMuted),
+            ),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: model.sending ? null : () => _onSend(model),
+              icon: model.sending
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(LucideIcons.send, size: 16),
+              label: Text(model.sending
+                  ? StringsSuggestions.sending
+                  : StringsSuggestions.send),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMineSection(
+      BondlyColorScheme colors, SuggestionsViewModel model) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          StringsSuggestions.mySuggestions,
+          style: GoogleFonts.montserrat(
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            color: colors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 8),
+        if (model.mine.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            child: Text(
+              StringsSuggestions.noneYet,
+              style: GoogleFonts.montserrat(
+                  fontSize: 13, color: colors.textMuted),
+            ),
+          )
+        else
+          ...model.mine.map((s) => _SuggestionTile(item: s, colors: colors)),
+      ],
+    );
+  }
+}
+
+class _SuggestionTile extends StatelessWidget {
+  final Suggestion item;
+  final BondlyColorScheme colors;
+
+  const _SuggestionTile({required this.item, required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(AppDimensions.radiusPill),
+        border: Border.all(color: colors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  item.title?.isNotEmpty == true
+                      ? item.title!
+                      : item.message,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: GoogleFonts.montserrat(
+                      fontSize: 14, fontWeight: FontWeight.w600),
+                ),
+              ),
+              SuggestionStatusChip(status: item.status),
+            ],
+          ),
+          if (item.title?.isNotEmpty == true) ...[
+            const SizedBox(height: 4),
+            Text(
+              item.message,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: GoogleFonts.montserrat(
+                  fontSize: 12, color: colors.textSecondary),
+            ),
+          ],
+          const SizedBox(height: 6),
+          Row(
+            children: [
+              if (item.category != null) ...[
+                Text(item.category!,
+                    style: GoogleFonts.montserrat(
+                        fontSize: 11, color: colors.textMuted)),
+                const SizedBox(width: 8),
+              ],
+              if (item.createdAt != null)
+                Text(
+                  DateFormat('dd MMM yyyy', 'es').format(item.createdAt!),
+                  style: GoogleFonts.montserrat(
+                      fontSize: 11, color: colors.textMuted),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/suggestions/ui/viewmodels/suggestions_viewmodel.dart
+++ b/lib/features/suggestions/ui/viewmodels/suggestions_viewmodel.dart
@@ -1,0 +1,79 @@
+import 'package:bondly_app/features/base/ui/viewmodels/base_model.dart';
+import 'package:bondly_app/features/suggestions/domain/models/suggestion.dart';
+import 'package:bondly_app/features/suggestions/domain/usecases/get_my_suggestions_usecase.dart';
+import 'package:bondly_app/features/suggestions/domain/usecases/submit_suggestion_usecase.dart';
+import 'package:logger/logger.dart';
+
+class SuggestionsViewModel extends NavigationModel {
+  final SubmitSuggestionUseCase _submitUseCase;
+  final GetMySuggestionsUseCase _getMineUseCase;
+
+  final Logger log = Logger(printer: PrettyPrinter(methodCount: 0));
+
+  SuggestionsViewModel(this._submitUseCase, this._getMineUseCase);
+
+  bool _sending = false;
+  bool get sending => _sending;
+
+  bool _anonymous = false;
+  bool get anonymous => _anonymous;
+  set anonymous(bool value) {
+    _anonymous = value;
+    notifyListeners();
+  }
+
+  String? _category;
+  String? get category => _category;
+  set category(String? value) {
+    _category = value;
+    notifyListeners();
+  }
+
+  List<Suggestion> _mine = [];
+  List<Suggestion> get mine => _mine;
+
+  Future<void> setUp() async {
+    await loadMine();
+  }
+
+  Future<void> loadMine() async {
+    final result = await _getMineUseCase.invoke();
+    result.when(
+      (items) => _mine = items,
+      (error) {
+        log.e('SuggestionsViewModel### loadMine: $error');
+        _mine = [];
+      },
+    );
+    notifyListeners();
+  }
+
+  /// Returns true when the suggestion was submitted successfully.
+  Future<bool> submit({required String message, String? title}) async {
+    _sending = true;
+    notifyListeners();
+
+    final result = await _submitUseCase.invoke(
+      message: message,
+      title: title,
+      category: _category,
+      anonymous: _anonymous,
+    );
+
+    bool ok = false;
+    result.when(
+      (_) => ok = true,
+      (error) => log.e('SuggestionsViewModel### submit: $error'),
+    );
+
+    _sending = false;
+    if (ok) {
+      _anonymous = false;
+      _category = null;
+      await loadMine();
+    } else {
+      notifyListeners();
+    }
+    return ok;
+  }
+}

--- a/lib/features/suggestions/ui/widgets/suggestion_status_chip.dart
+++ b/lib/features/suggestions/ui/widgets/suggestion_status_chip.dart
@@ -1,0 +1,30 @@
+import 'package:bondly_app/config/colors.dart';
+import 'package:bondly_app/config/strings_suggestions.dart';
+import 'package:bondly_app/ui/shared/tag_pill.dart';
+import 'package:flutter/material.dart';
+
+Color suggestionStatusColor(String status, BondlyColorScheme colors) =>
+    switch (status) {
+      'resuelta' => Colors.green,
+      'en_revision' => Colors.orange,
+      'archivada' => colors.textMuted,
+      _ => colors.accent,
+    };
+
+class SuggestionStatusChip extends StatelessWidget {
+  final String status;
+
+  const SuggestionStatusChip({super.key, required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<BondlyColorScheme>()!;
+    final color = suggestionStatusColor(status, colors);
+    return TagPill(
+      label: StringsSuggestions.statusLabel(status),
+      backgroundColor: color.withValues(alpha: 0.12),
+      textColor: color,
+      radius: 20,
+    );
+  }
+}

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -11,6 +11,7 @@ import 'package:bondly_app/features/admin/ui/screens/admin_permissions_screen.da
 import 'package:bondly_app/features/admin/ui/screens/admin_reports_screen.dart';
 import 'package:bondly_app/features/admin/ui/screens/admin_rewards_screen.dart';
 import 'package:bondly_app/features/admin/ui/screens/admin_settings_screen.dart';
+import 'package:bondly_app/features/admin/ui/screens/admin_suggestions_screen.dart';
 import 'package:bondly_app/features/admin/ui/screens/admin_shell_screen.dart';
 import 'package:bondly_app/features/admin/ui/screens/admin_users_screen.dart';
 import 'package:bondly_app/features/admin/ui/screens/admin_zones_screen.dart';
@@ -31,6 +32,7 @@ import 'package:bondly_app/features/profile/ui/screens/my_rewards_screen.dart';
 import 'package:bondly_app/features/profile/ui/screens/profile_screen.dart';
 import 'package:bondly_app/features/profile/ui/screens/shopping_cart_screen.dart';
 import 'package:bondly_app/features/ranking/ui/screens/ranking_screen.dart';
+import 'package:bondly_app/features/suggestions/ui/screens/suggestions_screen.dart';
 import 'package:bondly_app/features/start/ui/screens/start_screen.dart';
 import 'package:bondly_app/ui/shared/desktop_shell.dart';
 import 'package:go_router/go_router.dart';
@@ -44,6 +46,7 @@ List<String> _adminBreadcrumbs(String path) {
   if (path.startsWith('/admin/banners')) return ['Banners'];
   if (path.startsWith('/admin/news')) return ['Noticias'];
   if (path.startsWith('/admin/feeds')) return ['Moderación'];
+  if (path.startsWith('/admin/suggestions')) return ['Voz'];
   if (path.startsWith('/admin/ambassadors')) return ['Embajadores'];
   if (path.startsWith('/admin/reports')) return ['Reportes'];
   if (path == '/admin/settings/zones') return ['Configuración', 'Zonas'];
@@ -159,6 +162,11 @@ class AppRouter {
                 _fadePage(state, const AdminFeedsScreen()),
           ),
           GoRoute(
+            path: AdminSuggestionsScreen.route,
+            pageBuilder: (context, state) =>
+                _fadePage(state, const AdminSuggestionsScreen()),
+          ),
+          GoRoute(
             path: AdminReportsScreen.route,
             pageBuilder: (context, state) =>
                 _fadePage(state, const AdminReportsScreen()),
@@ -214,6 +222,9 @@ class AppRouter {
           GoRoute(
               path: RankingScreen.route,
               builder: (context, state) => const RankingScreen()),
+          GoRoute(
+              path: SuggestionsScreen.route,
+              builder: (context, state) => const SuggestionsScreen()),
           GoRoute(
               path: MyDataScreen.route,
               builder: (context, state) => const MyDataScreen()),

--- a/supabase/migrations/017_suggestions.sql
+++ b/supabase/migrations/017_suggestions.sql
@@ -1,0 +1,93 @@
+-- =============================================
+-- Bondly: "Voz" — Suggestion Box (Buzón de Sugerencias)
+-- =============================================
+-- Collaborators submit suggestions/inquiries, optionally anonymous.
+-- Admins triage them (status + internal note). Single-tenant RLS model (see 011).
+
+-- Lifecycle of a suggestion
+CREATE TYPE suggestion_status AS ENUM ('nueva', 'en_revision', 'resuelta', 'archivada');
+
+CREATE TABLE suggestions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Author. NULL when the suggestion is anonymous (identity is never stored).
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    is_anonymous BOOLEAN NOT NULL DEFAULT FALSE,
+    category TEXT,
+    title TEXT,
+    message TEXT NOT NULL,
+    status suggestion_status NOT NULL DEFAULT 'nueva',
+    -- Internal admin note / response (never exposed to the author).
+    admin_note TEXT,
+    visible BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_suggestions_status ON suggestions(status);
+CREATE INDEX idx_suggestions_created_at ON suggestions(created_at DESC);
+CREATE INDEX idx_suggestions_user_id ON suggestions(user_id);
+
+-- Keep updated_at fresh
+CREATE TRIGGER suggestions_updated_at
+    BEFORE UPDATE ON suggestions
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- =============================================
+-- RLS
+-- =============================================
+ALTER TABLE suggestions ENABLE ROW LEVEL SECURITY;
+
+-- Any authenticated user can submit. An anonymous suggestion must NOT carry an
+-- author id; a signed suggestion must carry the submitter's own id (no spoofing).
+CREATE POLICY "suggestions_insert_own" ON suggestions
+    FOR INSERT
+    WITH CHECK (
+        auth.uid() IS NOT NULL AND (
+            (is_anonymous AND user_id IS NULL) OR
+            (NOT is_anonymous AND user_id = auth.uid())
+        )
+    );
+
+-- Only admins can read the raw table (it holds admin_note, an internal field).
+-- Authors read their own suggestions through get_my_suggestions() below, which
+-- deliberately omits admin_note. Anonymous rows (user_id = NULL) are never
+-- returned to any client.
+CREATE POLICY "suggestions_select_admin" ON suggestions
+    FOR SELECT USING (public.is_admin());
+
+-- Admins manage everything (triage status, add notes, archive).
+CREATE POLICY "suggestions_manage_admin" ON suggestions
+    FOR ALL USING (public.is_admin());
+
+-- Author-facing read path. SECURITY DEFINER so it bypasses the admin-only SELECT
+-- policy, but it hard-filters to the caller's own non-anonymous rows and never
+-- exposes admin_note.
+CREATE OR REPLACE FUNCTION public.get_my_suggestions()
+RETURNS TABLE (
+    id UUID,
+    title TEXT,
+    category TEXT,
+    message TEXT,
+    status suggestion_status,
+    is_anonymous BOOLEAN,
+    created_at TIMESTAMPTZ
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT s.id, s.title, s.category, s.message, s.status, s.is_anonymous,
+           s.created_at
+    FROM suggestions s
+    WHERE s.user_id = auth.uid()
+      AND s.is_anonymous = FALSE
+      AND s.visible = TRUE
+    ORDER BY s.created_at DESC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_my_suggestions() TO authenticated;
+
+-- New admin module for the suggestion box. Safe with IF NOT EXISTS; value is not
+-- referenced elsewhere in this migration, so no in-transaction enum-use conflict.
+ALTER TYPE admin_permission ADD VALUE IF NOT EXISTS 'manage_suggestions';

--- a/supabase/migrations/018_suggestions_hardening.sql
+++ b/supabase/migrations/018_suggestions_hardening.sql
@@ -1,0 +1,43 @@
+-- =============================================
+-- Bondly: "Voz" — Suggestion Box hardening (follows 017)
+-- =============================================
+-- Two fixes from security review:
+--  1. Non-admin submitters could set status/admin_note/visible directly via
+--     PostgREST (RLS only constrained user_id/is_anonymous). A planted
+--     admin_note is especially dangerous in an HR complaint box. Force safe
+--     defaults for any caller that isn't a suggestion-box admin.
+--  2. Admin RLS used is_admin() (JWT-claim role), so the per-module
+--     `manage_suggestions` grant was UI-only — any admin could read/delete
+--     confidential complaints. Move to has_admin_permission(), which reads the
+--     role from the users table (guarded by 015) and honors the grant.
+
+-- 1. Clamp attacker-controllable columns on insert for non-privileged users.
+CREATE OR REPLACE FUNCTION public.enforce_suggestion_insert_defaults()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT has_admin_permission('manage_suggestions') THEN
+    NEW.status := 'nueva';
+    NEW.admin_note := NULL;
+    NEW.visible := TRUE;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER suggestions_enforce_insert_defaults
+    BEFORE INSERT ON suggestions
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_suggestion_insert_defaults();
+
+-- 2. Enforce the manage_suggestions grant at the DB. The FOR ALL policy also
+-- covers SELECT, so the separate admin-select policy from 017 is redundant.
+DROP POLICY IF EXISTS "suggestions_select_admin" ON suggestions;
+DROP POLICY IF EXISTS "suggestions_manage_admin" ON suggestions;
+
+CREATE POLICY "suggestions_manage_admin" ON suggestions
+    FOR ALL
+    USING (has_admin_permission('manage_suggestions'))
+    WITH CHECK (has_admin_permission('manage_suggestions'));


### PR DESCRIPTION
## Qué es

**Voz** es un buzón de sugerencias de doble cara: los colaboradores envían ideas/inquietudes —con nombre o de forma **anónima**— y RRHH las revisa desde el panel admin.

## Lado usuario (`/suggestionsScreen`, entrada desde el menú de Perfil → *Tu Voz*)
- Formulario: asunto (opcional), categoría, mensaje y switch de anonimato con explicación clara.
- *"Mis envíos"*: lista con el estado de las sugerencias firmadas del usuario.

## Lado admin (`/admin/suggestions`, módulo `manage_suggestions`)
- Bandeja con filtro por estado, autor (o **"Anónimo"**), fecha y categoría.
- Detalle: cambiar estado (Nueva / En revisión / Resuelta / Archivada), nota interna, borrar.
- Nuevo módulo registrado en los 3 lugares habituales (enum Dart, `_moduleLabel`, enum Postgres).

## La confidencialidad se garantiza en el backend, no solo en la UI
- **INSERT (RLS):** no puedes firmar como otro ni etiquetar un anónimo; los anónimos guardan `user_id = NULL` (nada que revelar).
- **Autor:** lee lo suyo vía `get_my_suggestions()` (`SECURITY DEFINER`) que **omite `admin_note`**; la tabla cruda solo la ven admins.
- **Hardening (migración 018):** las políticas usan `has_admin_permission('manage_suggestions')` (rol desde la tabla `users`, no del JWT), y un trigger fija `status`/`admin_note`/`visible` en envíos de no-admins → cierra el vector de "nota interna plantada".

## Migraciones
`017_suggestions.sql` y `018_suggestions_hardening.sql` — **ya aplicadas al proyecto Supabase remoto** (`supabase migration list` muestra 017/018 en local + remoto).

> Para dar acceso a un admin no-super: otorgarle el módulo *Voz* en la pantalla de Permisos (los superAdmin lo tienen automáticamente).

## Calidad
- `/simplify`: reutiliza el `TagPill` existente, labels de estado en un solo mapa, arreglado un pop de navigator equivocado en el diálogo de borrado, `.limit(100)` en la lista admin.
- `/security-review`: núcleo del diseño validado (sin spoofing de autor, sin fuga de `admin_note`, anónimos no de-anonimizables); los 2 hallazgos menores se corrigieron en la migración 018.
- `flutter analyze`: sin issues en el código de la feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Suggestions” area where people can submit categorized or anonymous feedback and review their previous submissions.
  * Added status indicators and submission progress/error feedback.
  * Added an admin Suggestions dashboard with filtering, status updates, notes, deletion, and retry handling.
  * Added permission-controlled navigation for suggestion management.
* **Bug Fixes**
  * Improved protection of suggestion data and enforced safe defaults for submitted feedback.
* **Chores**
  * Excluded local Supabase development artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->